### PR TITLE
Add test cases for SELinux module enablement and disablement

### DIFF
--- a/audit-many-2/selinux-labels.sh
+++ b/audit-many-2/selinux-labels.sh
@@ -1,0 +1,107 @@
+#!/bin/env sh
+
+# shellcheck disable=SC2059,SC3043
+#set -x
+
+. ./ns-common.sh
+SYNCFILE=${SYNCFILE:-syncfile}
+
+create_imans()
+{
+  mnt_securityfs "/mnt"
+}
+
+get_policy_string()
+{
+  local p1="$1"
+
+  local selinux_rules=""
+
+  if [ "${p1}" -eq 1 ]; then
+    selinux_rules="audit func=BPRM_CHECK mask=MAY_EXEC subj_type=${SELINUX_LABEL} \n"
+    selinux_rules="${selinux_rules}audit func=FILE_CHECK mask=MAY_READ obj_type=${SELINUX_LABEL} "
+  fi
+  echo "${selinux_rules}"
+}
+
+# Check that the policy shown by IMA is as expected
+# @param1: label rules are there: 1
+#          label rules are not there: 0
+check_policy()
+{
+  local has_rules="$1"
+
+  local policy tmp
+
+  policy="$(get_policy_string "${has_rules}")"
+  tmp="$(cat "/mnt/ima/policy")"
+  if [ "${tmp}" != "$(printf "${policy}")" ]; then
+    echo " Error: Unexpected policy in namespace"
+    echo " expected: |${policy}|"
+    echo " actual  : |${tmp}|"
+    echo > "${FAILFILE}"
+  fi
+}
+
+# Check that the policy has no rules with the SELinux label
+check_policy_no_label()
+{
+  check_policy 0
+}
+
+# Check that the policy has the rules with the SELinux label
+check_policy_has_label()
+{
+  check_policy 1
+}
+
+set_policy()
+{
+  local policy tmp
+
+  policy="$(get_policy_string 1)"
+  printf "${policy}" > "/mnt/ima/policy"
+  check_policy_has_label
+}
+
+stage=1
+while [ "${stage}" -lt 5 ]; do
+  syncfile="${SYNCFILE}-${stage}"
+
+  if [ "${NSID}" = "0" ]; then
+    # control container
+    wait_cage_full 0 "${syncfile}" "${NUM_CONTAINERS}"
+
+    case "${stage}" in
+    1) cmd="create-imans";;
+    2) cmd="set-policy";;
+    3) cmd="check-policy-no-label";echo "disabling module";/usr/sbin/semodule -d "${SELINUX_MODULE}";;
+    4) cmd="check-policy-has-label";echo "enabling module";/usr/sbin/semodule -e "${SELINUX_MODULE}";;
+    esac
+
+    [ -f "${FAILFILE}" ] && {
+      cmd="end"
+      /usr/sbin/semodule -e "${SELINUX_MODULE}"
+    }
+
+    echo "Stage: ${stage}   cmd: ${cmd}"
+
+    printf "${cmd}" > "${CMDFILE}"
+    open_cage "${syncfile}"
+  else
+    # testing container
+    wait_in_cage "${NSID}" "${syncfile}"
+
+    cmd="$(cat "${CMDFILE}")"
+    #echo "cmd=|${cmd}|"
+
+    case "${cmd}" in
+    create-imans)           create_imans;;
+    set-policy)             set_policy;;
+    check-policy-no-label)  check_policy_no_label;;
+    check-policy-has-label) check_policy_has_label;;
+    end)                    break;;
+    esac
+  fi
+  stage=$((stage+1))
+done

--- a/audit-many-2/test.sh
+++ b/audit-many-2/test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+#set -x
+
+#
+# Run tests with SELinux policy labels
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+check_root
+
+if ! type -p semodule | grep -q ^; then
+  echo " Error: semodule tool is not installed"
+  exit "${SKIP:-3}"
+fi
+
+SELINUX_LABEL="vmtools_exec_t"
+SELINUX_MODULE="vmtools"
+
+if ! semodule -l | grep -q "${SELINUX_MODULE}"; then
+  echo " Error: SELinux module ${SELINUX_MODULE} is not available"
+  exit "${SKIP:-3}"
+fi
+
+check_ima_support
+
+setup_busybox_container \
+	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
+	"${DIR}/selinux-labels.sh"
+
+#copy_elf_busybox_container \
+#	"$(which semodule)"
+
+# requires check.sh
+if ! check_ns_selinux_support; then
+  echo " Error: IMA does not support SELinux labels"
+  exit "${SKIP:-3}"
+fi
+
+rootfs="$(get_busybox_container_root)"
+
+# First container is just running the script on the host
+FAILFILE="failfile"
+CMDFILE="cmdfile"
+SYNCFILE="syncfile"
+
+testcase=1
+while [ "${testcase}" -le 3 ]; do
+
+  case "${testcase}" in
+  1) num=2;;
+  2) num=$(( $(nproc) ));;
+  3) num=$(( $(nproc) * 10));;
+  esac
+
+  echo "INFO: Testing disabling SELinux labels with ${num} containers"
+
+  pushd "${rootfs}" &>/dev/null || exit 1
+  NSID=0 NUM_CONTAINERS=$((1+num)) \
+    CMDFILE="${rootfs}/${CMDFILE}" \
+    SYNCFILE="${rootfs}/${SYNCFILE}" \
+    FAILFILE="${rootfs}/${FAILFILE}" \
+    SELINUX_MODULE=${SELINUX_MODULE} \
+    PATH=${rootfs}/bin/:${rootfs}/usr/bin/:${rootfs}/sbin/ \
+      ./selinux-labels.sh &
+  popd &>/dev/null || exit 1
+
+  for ((i=1; i<=num; i++)); do
+    NSID=${i} \
+      CMDFILE=${CMDFILE} \
+      SYNCFILE=${SYNCFILE} \
+      FAILFILE=${FAILFILE} \
+      SELINUX_LABEL=${SELINUX_LABEL} \
+      run_busybox_container ./selinux-labels.sh &
+  done
+
+  wait
+
+  if [ -f "${rootfs}${FAILFILE}" ]; then
+    echo "Error: Test ${testcase} failed"
+    exit "${FAIL:-1}"
+  fi
+
+  echo "INFO: Pass test ${testcase}"
+  testcase=$((testcase + 1))
+done
+
+exit "${SUCCESS:-0}"

--- a/check.sh
+++ b/check.sh
@@ -15,7 +15,7 @@ MNT=_mnt
 # Check whether IMA-ns is available at all
 if [ "${rc}" -eq 0 ]; then
   case "$1" in
-  securitfs|audit|measure|appraise) # securityfs is needed by all
+  securitfs|audit|measure|appraise|selinux) # securityfs is needed by all
     mkdir "${MNT}"
     if ! msg=$(mount -t securityfs "${MNT}" "${MNT}" 2>&1); then
       rc=1
@@ -50,6 +50,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check whether IMA-ns support audit or measure(+audit) or appraise+(measure+audit)
+# and SELinux labels
 if [ "${rc}" -eq 0 ]; then
   case "$1" in
   securitfs) ;;
@@ -68,6 +69,10 @@ if [ "${rc}" -eq 0 ]; then
       rc=1
     fi
     ;;
+  selinux)
+    if ! printf "audit func=BPRM_CHECK subj_type=bin_t\n" > "${MNT}/ima/policy"; then
+      rc=1
+    fi
   esac
 fi
 

--- a/common.sh
+++ b/common.sh
@@ -274,3 +274,9 @@ function check_ns_appraise_support()
 {
   run_busybox_container ./check.sh appraise
 }
+
+# Check whether there is SELinux support
+function check_ns_selinux_support()
+{
+  run_busybox_container ./check.sh selinux
+}

--- a/hash-1/hash.sh
+++ b/hash-1/hash.sh
@@ -1,16 +1,10 @@
 #!/bin/env sh
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC2143
 
 . ./ns-common.sh
 
 mnt_securityfs "/mnt"
-
-KEY=./rsakey.pem
-CERT=./rsa.crt
-
-keyctl newring _ima @s >/dev/null 2>&1
-keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
 
 policy='hash func=FILE_CHECK mask=MAY_READ \n'
 


### PR DESCRIPTION
This patch fixes the syntax-check in hash-1 test case and adds a test case for the enablement and disablement of an SELinux module that has to cause IMA rules to disappear and then re-appear.