### PR TITLE
common.sh: Use /var/lib/imatest when running as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ several hundred IMA namespaces/containers in parallel to test the locking and ot
 aspects of IMA namespaces.
 
 The test suite is based on several commonly available tools:
-- unshare from util-linux 2.36.2 (2.34 seems too old)
+- unshare from util-linux 2.36.2
 - busybox
 - keyctrl
 - getfattr/setfattr
 - ldd
 
-Some of the tests use features of the unshare tool that seem to be susceptible to the version
-of the unshare tool being used. Please use the recommended version.
+Some of the tests use features of the unshare tool that seem to be susceptible
+to the version of the unshare tool being used. Please use the recommended
+version, or one that is not too far away from it.
 
 Some of the results of the tests are dependent on the IMA compile time options. Until we
 figure out how to get a handle on all of them and deal with different results, please use

--- a/common.sh
+++ b/common.sh
@@ -7,7 +7,7 @@ AUDITLOG=/var/log/audit/audit.log
 if [ "$(id -u)" -ne 0 ] && [ -n "${HOME}" ]; then
  WORKDIR="${HOME}/.imatest"
 else
- WORKDIR="/var/run/imatest"
+ WORKDIR="/var/lib/imatest"
 fi
 
 function check_root()


### PR DESCRIPTION
Since /var/run is mounted noexec on Ubuntu, move to /var/lib/imatest
for copying tests to when running as root. It was likely not the
unshare tool that was too old to run certain tests but the noexec flag
of the mount.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>