### PR TITLE
Add test for appraising a signed policy file and add appraise-4 to test cases

### DIFF
--- a/appraise-4/test.sh
+++ b/appraise-4/test.sh
@@ -10,6 +10,12 @@ ROOT="${DIR}/.."
 
 source "${ROOT}/common.sh"
 
+# FIXME: Check why dd circumvents the check on O_DIRECT
+if [ "$(id -u)" -eq 0 ]; then
+  echo " Error: Cannot run this test as root"
+  exit "${SKIP:-3}"
+fi
+
 check_ima_support
 
 setup_busybox_container \
@@ -27,7 +33,7 @@ copy_elf_busybox_container "$(type -P dd)"
 
 echo "INFO: Testing O_DIRECT usage and appraisal inside container"
 
-run_busybox_container ./odirect.sh
+run_busybox_container_key_session ./odirect.sh
 rc=$?
 if [ $rc -ne 0 ] ; then
   echo " Error: Test failed in IMA namespace."

--- a/appraise-5/signed-policy.sh
+++ b/appraise-5/signed-policy.sh
@@ -1,0 +1,59 @@
+#!/bin/env sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC2059
+# set -x
+
+. ./ns-common.sh
+
+mnt_securityfs "/mnt"
+
+KEY=./rsakey.pem
+CERT=./rsa.crt
+
+keyctl newring _ima @s >/dev/null 2>&1
+keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
+
+prepolicy='dont_appraise fsmagic=0x73636673 \n'\
+'appraise func=POLICY_CHECK mask=MAY_READ \n'
+
+printf "${prepolicy}" > /mnt/ima/policy || {
+  echo " Error: Could not set policy appraise policy. Does IMA-ns support IMA-appraise?"
+  exit "${SKIP:-3}"
+}
+
+policy='appraise func=FILE_CHECK mask=MAY_READ uid=0 \n'
+printf "${policy}" > /policyfile
+
+echo "/policyfile" > /mnt/ima/policy 2>/dev/null && {
+  echo " Error: Could set unsigned policy"
+  exit "${FAIL:-1}"
+}
+
+if ! msg=$(evmctl ima_sign --imasig --key "${KEY}" -a sha256 "/policyfile" 2>&1); then
+  echo " Error: evmctl failed: ${msg}"
+  exit "${FAIL:-1}"
+fi
+
+echo "/policyfile" > /mnt/ima/policy 2>/dev/null || {
+  echo " Error: Could not set signed policy"
+  exit "${FAIL:-1}"
+}
+
+# try initial policy again
+printf "${prepolicy}" > /mnt/ima/policy && {
+  echo " Error: Could set policy by writing policy rules even though this should not work"
+  exit "${SKIP:-3}"
+}
+
+nspolicy=$(cat /mnt/ima/policy)
+expected=$(printf "${prepolicy}${policy}")
+if [ "${nspolicy}" != "${expected}" ]; then
+  echo " Error: Wrong policy in namespace"
+  echo "expected: |${expected}|"
+  echo "actual  : |${nspolicy}|"
+  exit "${FAIL:-1}"
+fi
+
+exit "${SUCCESS:-0}"

--- a/appraise-5/test.sh
+++ b/appraise-5/test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC1091
+#set -x
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+check_ima_support
+
+setup_busybox_container \
+	"${ROOT}/ns-common.sh" \
+	"${DIR}/signed-policy.sh" \
+	"${ROOT}/keys/rsakey.pem" \
+	"${ROOT}/keys/rsa.crt"
+
+copy_elf_busybox_container "$(type -P keyctl)"
+copy_elf_busybox_container "$(type -P evmctl)"
+
+# Test appraisal caused by executable run in namespace
+
+echo "INFO: Testing signed policy usage and policy appraisal inside container"
+
+run_busybox_container ./signed-policy.sh
+rc=$?
+if [ $rc -ne 0 ] ; then
+  echo " Error: Test failed in IMA namespace."
+  exit "$rc"
+fi
+
+echo "INFO: Pass"
+
+exit "${SUCCESS:-0}"

--- a/audit-2/test.sh
+++ b/audit-2/test.sh
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
+# shellcheck disable=SC2009
+
 #set -x
 
 DIR="$(dirname "$0")"
@@ -46,7 +48,6 @@ sudo -u "${TEST_USER}" \
   env PATH=/bin:/usr/bin SYNCFILE=${SYNCFILE} FAILFILE=${FAILFILE} \
   unshare --user --map-root-user --mount-proc \
     --pid --fork --root "${rootfs}" bin/sh ./setpolicy.sh "${id}" &
-SUDO_PID=$!
 for ((i = 0; i < 10; i++)); do
   SHELL_PID=$(ps aux |
     grep -E "^${TEST_USER}" |

--- a/testcases
+++ b/testcases
@@ -5,6 +5,7 @@ audit+measure-1/test.sh
 appraise-1/test.sh
 appraise-2/test.sh
 appraise-3/test.sh
+appraise-4/test.sh
 appraise-5/test.sh
 appraise-many-1/test.sh
 appraise-many-2/test.sh

--- a/testcases
+++ b/testcases
@@ -5,6 +5,7 @@ audit+measure-1/test.sh
 appraise-1/test.sh
 appraise-2/test.sh
 appraise-3/test.sh
+appraise-5/test.sh
 appraise-many-1/test.sh
 appraise-many-2/test.sh
 audit-many-1/test.sh


### PR DESCRIPTION
This PR adds a test for appraising a signed policy file in an IMA namespace.
It also add the appraise-4 test case to the list of test cases to run.