### PR TITLE
Show stats at end of test run and improve checks for SELinux support

### DIFF
--- a/audit-many-2/test.sh
+++ b/audit-many-2/test.sh
@@ -13,7 +13,11 @@ ROOT="${DIR}/.."
 
 source "${ROOT}/common.sh"
 
+check_allow_expensive_test
+
 check_root
+
+check_selinux_enabled
 
 if ! type -p semodule | grep -q ^; then
   echo " Error: semodule tool is not installed"

--- a/common.sh
+++ b/common.sh
@@ -59,6 +59,27 @@ function check_ima_support()
   fi
 }
 
+function check_selinux_enabled()
+{
+  if ! type -p selinuxenabled | grep -q ^; then
+    echo " Error: selinuxenabled tool is not installed"
+    exit "${SKIP:-3}"
+  fi
+
+  if ! selinuxenabled; then
+    echo " Error: SELinux is not enabled on this machine"
+    exit "${SKIP:-3}"
+  fi
+}
+
+function check_allow_expensive_test()
+{
+  if [ -z "${IMA_TEST_EXPENSIVE}" ]; then
+    echo " IMA_TEST_EXPENSIVE environment variable must be set for this test"
+    exit "${SKIP:-3}"
+  fi
+}
+
 function create_workdir()
 {
    rm -rf "${WORKDIR}"

--- a/imatest
+++ b/imatest
@@ -60,6 +60,7 @@ function imatest()
   local line=0 is_retry=0
   local testcases_lines=$(wc -l < ${testcases})
   local testcase rc
+  local stats_pass=0 stats_fail=0 stats_skip=0
 
   export SUCCESS=0
   export FAIL=1
@@ -106,15 +107,18 @@ function imatest()
         case "$rc" in
         ${SUCCESS})
           logit "${logfile}" "  Test completed successfully"
+          stats_pass=$((stats_pass + 1))
           ;;
         ${SKIP})
           logit "${logfile}" "  Skipping test"
+          stats_skip=$((stats_skip + 1))
           ;;
         ${SUCCESS_NEEDS_REBOOT})
           logit "${logfile}" "  Test completed successfully (trying next test before rebooting)"
           ;;
         ${FAIL})
           logit "${logfile}" "  Test failed."
+          stats_fail=$((stats_fail + 1))
           ;;
         ${RETRY_AFTER_REBOOT})
           if [ $is_retry -ne 0 ]; then
@@ -128,6 +132,9 @@ function imatest()
               rm -f ${statefile}
             fi
             echo "is_retry=1" >> ${statefile}
+            echo "stats_fail=${stats_fail}" >> ${statefile}
+            echo "stats_pass=${stats_pass}" >> ${statefile}
+            echo "stats_skip=${stats_skip}" >> ${statefile}
             reboot
           fi
           ;;
@@ -141,6 +148,13 @@ function imatest()
     fi
     popd &>/dev/null
   done
+
+  logit "${logfile}" "================================================================================="
+  logit "${logfile}" "Statistics:"
+  logit "${logfile}" "Fail: ${stats_fail}"
+  logit "${logfile}" "Pass: ${stats_pass}"
+  logit "${logfile}" "Skip: ${stats_skip}"
+  logit "${logfile}" "================================================================================="
 }
 
 function usage()


### PR DESCRIPTION
This PR:
- Adds printout of statistics of passes/skips/fails of tests at the end of the test log
- Improves checks for support of SELinux on the host