### PR TITLE
Test SETXATTR_CHECK with varying selection of allowed hash algos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Concerns for the testing are:
 | appraise-3      | Execution of unsigned file fails in container if parent container has appraise policy and succeeds once file is signed |
 | appraise-4      | O_DIRECT usage and policy rule with missing or avaiable permit_directio |
 | appraise-5      | Only signed policy accepted after POLICY_CHECK rule has been set |
+| appraise-6      | Testing of proper enforcement of appraisal policy rule with SETXATTR_CHECK and varying set of allowed hash algos |
 | appraise-many-1 | Concurrently running IMA namespaces with own keyrings appraise executables |
 | appraise-many-2 | Concurrently running IMA namespaces test appraisal and re-appraisal of files after file and signature modifications |
 | audit-1         | Simple setting of audit policy rule and verifying that audit log gets messages from IMA namespace. Modification of executable causes new audit message. |

--- a/appraise-6/setxattr-check.sh
+++ b/appraise-6/setxattr-check.sh
@@ -1,0 +1,80 @@
+#!/bin/env sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC2059,SC3043,SC3057
+# set -x
+
+get_hash_algo_strings()
+{
+  local flags="${1}"
+
+  local algos=""
+
+  [ $((flags & 1)) -ne 0 ] && algos="${algos},sha256"
+  [ $((flags & 2)) -ne 0 ] && algos="${algos},sha384"
+  [ $((flags & 4)) -ne 0 ] && algos="${algos},sha512"
+
+  # remove leading ,
+  [ "${algos:0:1}" = "," ] && algos="${algos:1}"
+  echo "${algos}"
+}
+
+. ./ns-common.sh
+
+mnt_securityfs "/mnt"
+
+ALGOS=${ALGOS:-1}
+KEY=./rsakey.pem
+
+algos_str=$(get_hash_algo_strings "${ALGOS}")
+[ -z "${algos_str}" ] && exit "${SUCCESS:-0}"
+
+policy="appraise func=SETXATTR_CHECK appraise_algos=${algos_str} \n"
+
+printf "${policy}" > /mnt/ima/policy || {
+  echo " Error: Could not set appraise policy with SETXATTR_CHECK rule. Does IMA-ns support IMA-appraise?"
+  echo " policy: |${policy}|"
+  exit "${SKIP:-3}"
+}
+
+echo > testfile
+algo=1
+while [ "${algo}" -le 4 ]; do
+  pass=0
+  algo_str=$(get_hash_algo_strings "${algo}")
+
+  evmctl ima_sign --imasig --key "${KEY}" -a "${algo_str}" testfile 1>/dev/null 2>&1 && pass=1
+
+  # if algo is a bit set in ALGOS, then the test must pass, since algo is in policy
+  mustpass=$((ALGOS & algo))
+  case "${pass}" in
+  0)
+    case "${mustpass}" in
+    0)
+      # echo " GOOD: Could not sign file with hash ${algo_str} since not in ${algos_str}"
+      ;;
+    *)
+      echo " Error: Could not write xattr for file signed with hash ${algo_str} even though it should be possible"
+      echo " policy: |${policy}|"
+      exit "${FAIL:-1}"
+      ;;
+    esac
+    ;;
+  1)
+    case "${mustpass}" in
+    0)
+      echo " Error: Could write xattr for file signed with hash ${algo_str} even though it should NOT be possible"
+      echo " policy: |${policy}|"
+      exit "${FAIL:-1}"
+      ;;
+    *)
+      # echo " GOOD: Could sign file with hash ${algo_str} since it is in ${algos_str}"
+      ;;
+    esac
+    ;;
+  esac
+  algo=$((algo * 2))
+done
+
+exit "${SUCCESS:-0}"

--- a/appraise-6/test.sh
+++ b/appraise-6/test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC1091
+#set -x
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+check_ima_support
+
+setup_busybox_container \
+	"${ROOT}/ns-common.sh" \
+	"${DIR}/setxattr-check.sh" \
+	"${ROOT}/keys/rsakey.pem"
+
+copy_elf_busybox_container "$(type -P evmctl)"
+
+# Test appraisal caused by executable run in namespace
+
+echo "INFO: Testing appraisal policy with SEXATTR_CHECK rules inside container"
+
+for ((algos = 1; algos <= 15; algos++)) {
+  ALGOS=${algos} run_busybox_container ./setxattr-check.sh
+  rc=$?
+  if [ "${rc}" -ne 0 ] ; then
+    echo " Error: Test failed in IMA namespace."
+    exit "$rc"
+  fi
+}
+
+echo "INFO: Pass"
+
+exit "${SUCCESS:-0}"

--- a/testcases
+++ b/testcases
@@ -5,6 +5,7 @@ appraise-2/test.sh
 appraise-3/test.sh
 appraise-4/test.sh
 appraise-5/test.sh
+appraise-6/test.sh
 appraise-many-1/test.sh
 appraise-many-2/test.sh
 audit-1/test.sh


### PR DESCRIPTION
Add a test case that creates an appraisal policy rule with
func=SETXATTR_CHECK and a varying set of sha algorithms. Try out signing
a testfile with hashed with varying types of sha hashes of which those
that are in the policy rule must succeed and others must fail.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>