### PR TITLE
Add test case to configure an IMA namespace with hash algo and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Concerns for the testing are:
 | audit+measure-1 | Measuring and auditing of file; re-measuring and re-auditing of file after file modifcation; cuasing of open_writes and ToMToU audit message |
 | hash-1          | Ensuring that a hash is generated on a file following hash policy rule |
 | measure-1       | Measuring of an executed file and re-measuring after modification of the file|
+| measure-2       | Configure namespace with hash algorithm and template |
 | measure-many-1  | Concurrently running IMA namespaces measure an executable |
 | measure-many-2  | Measurements taken in nested containers up to 32 user spaces deep; executable run in one container is also measured in parent containers|
 | measure-many-3  | Concurrently running IMA namespaces measure many generated scripts and check log |

--- a/common.sh
+++ b/common.sh
@@ -125,7 +125,7 @@ function setup_busybox_container()
   cp "${busybox}" "${rootfs}/bin"
   pushd "${rootfs}/bin" 1>/dev/null || exit "${FAIL:-1}"
   for prg in \
-      cat chmod cut cp echo env find grep ls mkdir mount rm \
+      cat chmod cut cp echo env find grep head ls mkdir mount rm \
       sh sha1sum sha256sum sha384sum sha512sum sleep sync tail which; do
     ln -s busybox ${prg}
   done

--- a/measure-2/configure-ima-ns.sh
+++ b/measure-2/configure-ima-ns.sh
@@ -1,0 +1,107 @@
+#!/bin/env sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC3043
+
+. ./ns-common.sh
+
+# Get a hash name given a number's lowest 3 bits
+get_hash()
+{
+  local id="${1}"
+
+  local h
+
+  case "$((id & 7))" in
+  0) h="md5";;
+  1) h="sha1";;
+  2) h="sha256";;
+  3) h="sha384";;
+  4) h="sha512";;
+  5) h="sha224";;
+  *) h="sha224";;
+  esac
+
+  echo "${h}"
+}
+
+# Get a template name given a number's bits 3,4, and 5
+get_template()
+{
+  local id="${1}"
+
+  local t
+
+  case "$(((id >> 3) & 7))" in
+  0) t="ima";;
+  1) t="ima-ng";;
+  2) t="ima-buf";;
+  3) t="ima-sig";;
+  4) t="ima-modsig";;
+  5) t="evm-sig";;
+  *) t="evm-sig";;
+  esac
+
+  echo "${t}"
+}
+
+hash_algo=$(get_hash "${ID}")
+template=$(get_template "${ID}")
+mntdir="/mnt"
+
+if ! msg=$(mount -t securityfs "${mntdir}" "${mntdir}" 2>&1); then
+  echo " Error: Could not mount securityfs: ${msg}"
+  exit "${SKIP:-3}"
+fi
+
+if [ ! -f "${mntdir}/ima/hash" ]; then
+  echo " Error: Missing hash file in IMA's securityfs"
+  exit "${SKIP:-3}"
+fi
+
+if [ ! -f "${mntdir}/ima/template_name" ]; then
+  echo " Error: Missing template file in IMA's securityfs"
+  exit "${SKIP:-3}"
+fi
+
+if ! echo "${hash_algo}" > "${mntdir}/ima/hash"; then
+  echo " Error: Could not write '${hash_algo}' to IMA securityfs file"
+  exit "${FAIL:-1}"
+fi
+
+if ! echo "${template}" > "${mntdir}/ima/template_name"; then
+  echo " Error: Could not write '${template}' to IMA securityfs file"
+  exit "${FAIL:-1}"
+fi
+
+if ! echo "1" > "${mntdir}/ima/active"; then
+  echo " Error: Could not activate IMA namespace"
+  echo " hash:     ${hash_algo}"
+  echo " template: ${template}"
+  exit "${FAIL:-1}"
+fi
+
+t=$(get_template_from_log "${mntdir}")
+
+if [ "${t}" != "${template}" ]; then
+  echo " Error: Template in use by namespace is different from the one configured"
+  echo " expected : ${template}"
+  echo " actual   : ${t}"
+fi
+
+h=$(determine_file_hash_from_log "${mntdir}")
+
+# The 'ima' template only accepts md5 and sha1 and falls back to sha1 for all others
+# so just check the other ones templates.
+if [ "${t}" !=  "ima" ]; then
+  if [ "${h}" != "${hash_algo}" ]; then
+    echo " Error: Hash algo in use by namespace is different from the one configured"
+    echo " expected : ${hash_algo}"
+    echo " actual   : ${h}"
+  fi
+fi
+
+# cat "${mntdir}/ima/ascii_runtime_measurements"
+
+exit "${SUCCESS:-0}"

--- a/measure-2/test.sh
+++ b/measure-2/test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC1091
+#set -x
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+check_ima_support
+
+setup_busybox_container \
+	"${ROOT}/ns-common.sh" \
+	"${DIR}/configure-ima-ns.sh"
+
+# Test measurements caused by executable run in namespace
+
+echo "INFO: Testing configuration of IMA-ns with hash and template inside container"
+
+for ((i = 0; i < 64; i++)) do
+  ID=${i} run_busybox_container ./configure-ima-ns.sh
+  rc=$?
+  if [ $rc -ne 0 ] ; then
+    echo " Error: Test failed in IMA namespace."
+    exit "$rc"
+  fi
+done
+
+echo "INFO: Pass"
+
+exit "${SUCCESS:-0}"

--- a/measure-many-4/measure.sh
+++ b/measure-many-4/measure.sh
@@ -22,7 +22,7 @@ echo "${policy}" > /mnt/ima/policy || {
 
 testfile="testfile"
 
-imahash="$(determine_file_hash_from_log /mnt/ima/ascii_runtime_measurements)"
+imahash="$(determine_file_hash_from_log "/mnt")"
 
 reported=0
 

--- a/ns-common.sh
+++ b/ns-common.sh
@@ -87,13 +87,14 @@ open_cage()
 }
 
 # Determine the hash being used by ima for hashing a file
+# @param1: securityfs mount point
 determine_file_hash_from_log()
 {
-  local logfile="$1"
+  local mntdir="$1"
 
   local imahash
 
-  imahash=$(tail -n1 < "${logfile}" | cut -d" " -f4 | cut -d":" -f1)
+  imahash=$(tail -n1 < "${mntdir}/ima/ascii_runtime_measurements" | cut -d" " -f4 | cut -d":" -f1)
 
   case "${imahash}" in
   sha1) ;;

--- a/testcases
+++ b/testcases
@@ -1,4 +1,3 @@
-measure-1/test.sh
 audit+measure-1/test.sh
 appraise-1/test.sh
 appraise-2/test.sh
@@ -13,6 +12,8 @@ audit-2/test.sh
 audit-3/test.sh
 audit-many-1/test.sh
 audit-many-2/test.sh
+measure-1/test.sh
+measure-2/test.sh
 measure-many-1/test.sh
 measure-many-2/test.sh
 measure-many-3/test.sh


### PR DESCRIPTION
Add a test case to configure an IMA namespace in its configuration stage
by setting various hash algorithms and templates and ensuring that the IMA
namespace can be activated and the boot aggregate shows that the
configuration is being used.