### PR TITLE
Add check functions for support of measure/appraise/hash to all tests

### DIFF
--- a/appraise-1/test.sh
+++ b/appraise-1/test.sh
@@ -14,6 +14,7 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/appraise.sh" \
 	"${DIR}/reappraise.sh" \
 	"${DIR}/reappraise-after-host-file-modification.sh" \
@@ -21,6 +22,11 @@ setup_busybox_container \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt" \
 	"${ROOT}/keys/rsakey2.pem"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P keyctl)"
 copy_elf_busybox_container "$(type -P evmctl)"

--- a/appraise-2/test.sh
+++ b/appraise-2/test.sh
@@ -10,15 +10,21 @@ ROOT="${DIR}/.."
 
 source "${ROOT}/common.sh"
 
-check_root_or_sudo
-
 check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/reappraise-after-host-file-signing.sh" \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
+
+check_root_or_sudo
 
 copy_elf_busybox_container "$(type -P keyctl)"
 copy_elf_busybox_container "$(type -P evmctl)"

--- a/appraise-3/test.sh
+++ b/appraise-3/test.sh
@@ -13,11 +13,17 @@ source "${ROOT}/common.sh"
 check_ima_support
 
 setup_busybox_container \
+	"${ROOT}/check.sh" \
 	"${DIR}/child.sh" \
 	"${DIR}/parent.sh" \
 	"${ROOT}/ns-common.sh" \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P unshare)"
 copy_elf_busybox_container "$(type -P keyctl)"

--- a/appraise-4/test.sh
+++ b/appraise-4/test.sh
@@ -20,10 +20,16 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/odirect.sh" \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt" \
 	"$(type -P ldd)"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P keyctl)"
 copy_elf_busybox_container "$(type -P evmctl)"

--- a/appraise-5/test.sh
+++ b/appraise-5/test.sh
@@ -14,9 +14,15 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/signed-policy.sh" \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P keyctl)"
 copy_elf_busybox_container "$(type -P evmctl)"

--- a/appraise-6/test.sh
+++ b/appraise-6/test.sh
@@ -14,8 +14,14 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/setxattr-check.sh" \
 	"${ROOT}/keys/rsakey.pem"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P evmctl)"
 

--- a/audit+measure-1/test.sh
+++ b/audit+measure-1/test.sh
@@ -18,10 +18,16 @@ check_auditd
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/measure+audit.sh" \
 	"${DIR}/remeasure+reaudit.sh" \
 	"${DIR}/tomtou.sh" \
 	"${DIR}/open_writers.sh"
+
+if ! check_ns_measure_support; then
+  echo " Error: IMA-ns does not support IMA-measure"
+  exit "${SKIP:-3}"
+fi
 
 # Test auditing + measurements caused by executable run in namespace
 

--- a/audit-1/test.sh
+++ b/audit-1/test.sh
@@ -18,8 +18,14 @@ check_auditd
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/audit.sh" \
 	"${DIR}/reaudit.sh"
+
+if ! check_ns_audit_support; then
+  echo " Error: IMA-ns does not support IMA-audit"
+  exit "${SKIP:-3}"
+fi
 
 # Test auditing caused by executable run in namespace
 

--- a/audit-2/test.sh
+++ b/audit-2/test.sh
@@ -30,7 +30,13 @@ fi
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/setpolicy.sh"
+
+if ! check_ns_audit_support; then
+  echo " Error: IMA-ns does not support IMA-audit"
+  exit "${SKIP:-3}"
+fi
 
 rootfs=$(get_busybox_container_root)
 

--- a/audit-3/test.sh
+++ b/audit-3/test.sh
@@ -17,7 +17,13 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/feed-many-rules.sh"
+
+if ! check_ns_audit_support; then
+  echo " Error: IMA-ns does not support IMA-audit"
+  exit "${SKIP:-3}"
+fi
 
 # hardcoded limit number of rules in kernel: 1024
 LIMIT_RULES=1024

--- a/audit-many-1/test.sh
+++ b/audit-many-1/test.sh
@@ -23,7 +23,7 @@ setup_busybox_container \
 
 # requires check.sh
 if ! check_ns_audit_support; then
-  echo " Error: IMA-ns does not support IMA-measure"
+  echo " Error: IMA-ns does not support IMA-audit"
   exit "${SKIP:-3}"
 fi
 

--- a/check.sh
+++ b/check.sh
@@ -17,7 +17,7 @@ MNT=_mnt
 # Check whether IMA-ns is available at all
 if [ "${rc}" -eq 0 ]; then
   case "$1" in
-  securitfs|audit|measure|appraise|selinux) # securityfs is needed by all
+  securitfs|audit|measure|appraise|hash|selinux) # securityfs is needed by all
     mkdir "${MNT}"
     if ! msg=$(mount -t securityfs "${MNT}" "${MNT}" 2>&1); then
       rc=1
@@ -68,6 +68,11 @@ if [ "${rc}" -eq 0 ]; then
     ;;
   appraise)
     if ! printf "appraise func=BPRM_CHECK\n" > "${MNT}/ima/policy"; then
+      rc=1
+    fi
+    ;;
+  hash)
+    if ! printf "hash func=FILE_CHECK\n" > "${MNT}/ima/policy"; then
       rc=1
     fi
     ;;

--- a/common.sh
+++ b/common.sh
@@ -310,6 +310,12 @@ function check_ns_appraise_support()
   run_busybox_container ./check.sh appraise
 }
 
+# Check whether the namespace has IMA-appraise hash support
+function check_ns_hash_support()
+{
+  run_busybox_container ./check.sh hash
+}
+
 # Check whether there is SELinux support
 function check_ns_selinux_support()
 {

--- a/hash-1/test.sh
+++ b/hash-1/test.sh
@@ -14,10 +14,16 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/hash.sh" \
 	"${ROOT}/keys/rsakey.pem" \
 	"${ROOT}/keys/rsa.crt" \
 	"${ROOT}/keys/rsakey2.pem"
+
+if ! check_ns_hash_support; then
+  echo " Error: IMA-ns does not support IMA-appraise hash rules"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P getfattr)"
 

--- a/measure-1/test.sh
+++ b/measure-1/test.sh
@@ -14,8 +14,14 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/measure.sh" \
 	"${DIR}/remeasure.sh"
+
+if ! check_ns_measure_support; then
+  echo " Error: IMA-ns does not support IMA-measure"
+  exit "${SKIP:-3}"
+fi
 
 # Test measurements caused by executable run in namespace
 

--- a/measure-2/test.sh
+++ b/measure-2/test.sh
@@ -14,7 +14,13 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/configure-ima-ns.sh"
+
+if ! check_ns_measure_support; then
+  echo " Error: IMA-ns does not support IMA-measure"
+  exit "${SKIP:-3}"
+fi
 
 # Test measurements caused by executable run in namespace
 

--- a/measure-many-2/test.sh
+++ b/measure-many-2/test.sh
@@ -14,7 +14,13 @@ check_ima_support
 
 setup_busybox_container \
 	"${ROOT}/ns-common.sh" \
+	"${ROOT}/check.sh" \
 	"${DIR}/measure.sh"
+
+if ! check_ns_measure_support; then
+  echo " Error: IMA-ns does not support IMA-measure"
+  exit "${SKIP:-3}"
+fi
 
 copy_elf_busybox_container "$(type -P unshare)"
 


### PR DESCRIPTION
So that tests exit with the same error message if a to-be-tested feature is not available in the namespace, add check functions to all test.sh where it was missing.