### PR TITLE
audit: Grep for full path of executable in audit log

### DIFF
--- a/au+me+app-1/test.sh
+++ b/au+me+app-1/test.sh
@@ -38,7 +38,8 @@ num_extra=0
 ctr=$(grep -c -E '^audit.*func=BPRM_CHECK .*MAY_EXEC' /sys/kernel/security/ima/policy)
 [ "${ctr}" -ne 0 ] && num_extra=1
 
-before=$(grep -c "type=INTEGRITY_RULE .*rootfs/bin/busybox2" "${AUDITLOG}")
+rootfs=$(get_busybox_container_root)
+before=$(grep -c "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" "${AUDITLOG}")
 
 echo "INFO: Testing auditing+measuring+appraising caused by executable in container and re-auditing+re-measuring+re-appraising after file modification by host"
 
@@ -57,7 +58,7 @@ if [ "${rc}" -ne 0 ] ; then
 fi
 
 expected=$((before + 1 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .*rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   wait_child_exit_with_child_failure "${childpid}"
   echo " Error: Wrong number of busybox2 entries in audit log."

--- a/audit+measure-2/test.sh
+++ b/audit+measure-2/test.sh
@@ -33,7 +33,8 @@ num_extra=0
 ctr=$(grep -c -E '^audit.*func=BPRM_CHECK .*MAY_EXEC' /sys/kernel/security/ima/policy)
 [ "${ctr}" -ne 0 ] && num_extra=1
 
-before=$(grep -c "type=INTEGRITY_RULE .*rootfs/bin/busybox2" "${AUDITLOG}")
+rootfs=$(get_busybox_container_root)
+before=$(grep -c "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" "${AUDITLOG}")
 
 echo "INFO: Testing auditing+measuring caused by executable in container and re-auditing+re-measuring after file modification by host"
 
@@ -50,7 +51,7 @@ if [ "${rc}" -ne 0 ] ; then
 fi
 
 expected=$((before + 1 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .*rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   wait_child_exit_with_child_failure "${childpid}"
   echo " Error: Wrong number of busybox2 entries in audit log."
@@ -58,7 +59,6 @@ if [ $((expected)) -ne "${after}" ]; then
   exit "${FAIL:-1}"
 fi
 
-rootfs=$(get_busybox_container_root)
 syncfile="${rootfs}/syncfile"
 
 if ! wait_for_file "${syncfile}" 20; then
@@ -78,7 +78,7 @@ if ! wait_for_file "${syncfile}" 20; then
 fi
 
 expected=$((before + 2 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .*rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   wait_child_exit_with_child_failure "${childpid}"
   echo " Error: Wrong number of busybox2 entries in audit log."

--- a/audit-1/test.sh
+++ b/audit-1/test.sh
@@ -34,7 +34,8 @@ num_extra=0
 ctr=$(grep -c -E '^audit.*func=BPRM_CHECK .*MAY_EXEC' /sys/kernel/security/ima/policy)
 [ "${ctr}" -ne 0 ] && num_extra=1
 
-before=$(grep -c "rootfs/bin/busybox2" "${AUDITLOG}")
+rootfs=$(get_busybox_container_root)
+before=$(grep -c "file=\"${rootfs}/bin/busybox2\"" "${AUDITLOG}")
 
 echo "INFO: Testing auditing caused by executable in container"
 
@@ -49,7 +50,7 @@ if [ "${rc}" -ne 0 ] ; then
 fi
 
 expected=$((before + 1 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   echo " Error: Wrong number of busybox2 entries in audit log."
   echo "        Expected $((expected - before)) more log entries. Expected ${expected}, found ${after}."
@@ -75,7 +76,7 @@ if [ ${rc} -ne 0 ] ; then
 fi
 
 expected=$((before + 2 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   echo " Error: Wrong number of busybox2 entries in audit log."
   echo "        Expected $((expected - before)) more log entries. Expected ${expected}, found ${after}."

--- a/audit-3/test.sh
+++ b/audit-3/test.sh
@@ -33,7 +33,8 @@ num_extra=0
 ctr=$(grep -c -E '^audit.*func=BPRM_CHECK .*MAY_EXEC' /sys/kernel/security/ima/policy)
 [ "${ctr}" -ne 0 ] && num_extra=1
 
-before=$(grep -c "type=INTEGRITY_RULE .*rootfs/bin/busybox2" "${AUDITLOG}")
+rootfs=$(get_busybox_container_root)
+before=$(grep -c "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" "${AUDITLOG}")
 
 echo "INFO: Testing auditing caused by executable in container and re-auditing after file modification by host"
 
@@ -49,7 +50,7 @@ if [ "${rc}" -ne 0 ] ; then
 fi
 
 expected=$((before + 1 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .*rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   wait_child_exit_with_child_failure "${childpid}"
   echo " Error: Wrong number of busybox2 entries in audit log."
@@ -57,7 +58,6 @@ if [ $((expected)) -ne "${after}" ]; then
   exit "${FAIL:-1}"
 fi
 
-rootfs=$(get_busybox_container_root)
 syncfile="${rootfs}/syncfile"
 
 if ! wait_for_file "${syncfile}" 20; then
@@ -77,7 +77,7 @@ if ! wait_for_file "${syncfile}" 20; then
 fi
 
 expected=$((before + 2 + num_extra))
-after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .*rootfs/bin/busybox2" $((expected)) 30)
+after=$(wait_num_entries "${AUDITLOG}" "type=INTEGRITY_RULE .* file=\"${rootfs}/bin/busybox2\"" $((expected)) 30)
 if [ $((expected)) -ne "${after}" ]; then
   wait_child_exit_with_child_failure "${childpid}"
   echo " Error: Wrong number of busybox2 entries in audit log."


### PR DESCRIPTION
Grep for the full path of the executable in the audit log
rather than starting at 'rootfs/'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>