### PR TITLE
imatest: Skip commented-out test cases

### DIFF
--- a/imatest
+++ b/imatest
@@ -100,7 +100,7 @@ function imatest()
     echo "line=${line}" > "${statefile}"
 
     testcase=$(sed -n "${line}p" "${testcases}")
-    if [ -n "$(echo "${testcase}" | tr -d " ")" ]; then
+    if [ "${testcase:0:1}" != "#" ] && [ -n "$(echo "${testcase}" | tr -d " ")" ]; then
       local testcase_dir
 
       testcase_dir=$(dirname "${testcase}")


### PR DESCRIPTION
Skip test cases commented-out with first character '#' in the line.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>