### PR TITLE
Print better messages to determine reasons for failures

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -184,6 +184,8 @@ function setup_busybox_container()
   rootfs="$(get_busybox_container_root)"
 
   mkdir -p "${rootfs}"/{bin,mnt,proc,dev}
+  rm -f "${rootfs}"/dev/kmsg
+  mknod "${rootfs}"/dev/kmsg c 1 11
 
   while [ $# -ne 0 ]; do
     if ! cp "$1" "${rootfs}"; then
@@ -199,7 +201,7 @@ function setup_busybox_container()
   fi
   pushd "${rootfs}/bin" 1>/dev/null || exit "${FAIL:-1}"
   for prg in \
-      cat chmod cut cp dirname echo env find grep head ls mkdir mount mv printf rm \
+      cat chmod cut cp date dirname echo env find grep head ls mkdir mount mv printf rm \
       sh sha1sum sha256sum sha384sum sha512sum sleep sync \
       tail time which; do
     ln -s busybox ${prg}

--- a/vtpm-1/measure.sh
+++ b/vtpm-1/measure.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC3037
 
 . ./ns-common.sh
 
@@ -26,7 +26,9 @@ ctr_extends=$(grep -c \
                    /swtpm.log)
 ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
-  echo " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}."
+  msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
+  echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \
+          " dmsg output for last 30 seconds for tpm${VTPM_DEVICE_NUM}: ${msg}"
   exit "${FAIL:-1}"
 fi
 

--- a/vtpm-1/test.sh
+++ b/vtpm-1/test.sh
@@ -34,6 +34,7 @@ fi
 copy_elf_busybox_container "$(which swtpm)"
 copy_elf_busybox_container "$(which swtpm_ioctl)"
 copy_elf_busybox_container "${VTPM_EXEC}" "bin/"
+copy_elf_busybox_container "$(which dmesg)" "bin/"
 
 # The following test needs swtpm and ${VTPM_EXEC} copied
 if ! check_ns_vtpm_support; then

--- a/vtpm-2/measure.sh
+++ b/vtpm-2/measure.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC3037
 
 . ./ns-common.sh
 
@@ -26,7 +26,9 @@ ctr_extends=$(grep -c \
                    /swtpm.log)
 ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
-  echo " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}."
+  msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
+  echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \
+          " dmsg output for last 30 seconds for tpm${VTPM_DEVICE_NUM}: ${msg}"
   exit "${FAIL:-1}"
 fi
 

--- a/vtpm-2/test.sh
+++ b/vtpm-2/test.sh
@@ -34,6 +34,7 @@ fi
 copy_elf_busybox_container "$(which swtpm)"
 copy_elf_busybox_container "$(which swtpm_ioctl)"
 copy_elf_busybox_container "${VTPM_EXEC}" "bin/"
+copy_elf_busybox_container "$(which dmesg)" "bin/"
 
 # The following test needs swtpm and ${VTPM_EXEC} copied
 if ! check_ns_vtpm_support; then

--- a/vtpm-exec/vtpm-exec.c
+++ b/vtpm-exec/vtpm-exec.c
@@ -93,10 +93,9 @@ static int vtpm_proxy_connect_imans(int fd)
     n = ioctl(fd, VTPM_PROXY_IOC_CONNECT_TO_IMA_NS, 0);
     if (n < 0) {
         fprintf(stderr,
-                "Could not connect vtpm proxy to IMA namespace: "
-                "ioctl on fd %d failed: %s\n", fd, strerror(errno));
-        fprintf(stderr,
-                "[VTPM_DEVICE_NUM=%s]\n",getenv("VTPM_DEVICE_NUM"));
+                "Could not connect vtpm proxy (/dev/tpm%s) to IMA namespace: "
+                "ioctl on fd %d failed: %s\n",
+                getenv("VTPM_DEVICE_NUM"), fd, strerror(errno));
         return errno;
     }
 

--- a/vtpm-many-1/measure.sh
+++ b/vtpm-many-1/measure.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC3037
 
 # Caller must pass:
 # NSID: distinct namespace id number
@@ -33,7 +33,9 @@ ctr_extends=$(grep -c \
                    "${SWTPM_LOG}")
 ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
-  echo " Error: Expected ${ctr_measure} PCR_Extends but found ${ctr_extends}."
+  msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
+  echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \
+          " dmsg output for last 30 seconds for tpm${VTPM_DEVICE_NUM}: ${msg}"
   echo > "${FAILFILE}"
   exit "${FAIL:-1}"
 fi

--- a/vtpm-many-1/test.sh
+++ b/vtpm-many-1/test.sh
@@ -34,6 +34,7 @@ fi
 copy_elf_busybox_container "$(which swtpm)"
 copy_elf_busybox_container "$(which swtpm_ioctl)"
 copy_elf_busybox_container "${VTPM_EXEC}" "bin/"
+copy_elf_busybox_container "$(which dmesg)" "bin/"
 
 # The following test needs swtpm and ${VTPM_EXEC} copied
 if ! check_ns_vtpm_support; then

--- a/vtpm-many-2/measure.sh
+++ b/vtpm-many-2/measure.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC3037
 
 # Caller must pass:
 # NSID: distinct namespace id number
@@ -33,7 +33,9 @@ ctr_extends=$(grep -c \
                    "${SWTPM_LOG}")
 ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
-  echo " Error: Expected ${ctr_measure} PCR_Extends but found ${ctr_extends}."
+  msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
+  echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \
+          " dmsg output for last 30 seconds for tpm${VTPM_DEVICE_NUM}: ${msg}"
   echo > "${FAILFILE}"
   exit "${FAIL:-1}"
 fi

--- a/vtpm-many-2/test.sh
+++ b/vtpm-many-2/test.sh
@@ -34,6 +34,7 @@ fi
 copy_elf_busybox_container "$(which swtpm)"
 copy_elf_busybox_container "$(which swtpm_ioctl)"
 copy_elf_busybox_container "${VTPM_EXEC}" "bin/"
+copy_elf_busybox_container "$(which dmesg)" "bin/"
 
 # The following test needs swtpm and ${VTPM_EXEC} copied
 if ! check_ns_vtpm_support; then

--- a/vtpm-many-3/measure.sh
+++ b/vtpm-many-3/measure.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: BSD-2-Clause
 
-# shellcheck disable=SC2059
+# shellcheck disable=SC2059,SC3037
 
 # Caller must pass:
 # NSID: distinct namespace id number
@@ -64,7 +64,9 @@ if [ "${exp}" -ne "${ctr_extends}" ]; then
   exit "${FAIL:-1}"
 fi
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
-  echo " Error: Expected ${ctr_measure} PCR_Extends for PCR ${pcr} but found ${ctr_extends}."
+  msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
+  echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \
+          " dmsg output for last 30 seconds for tpm${VTPM_DEVICE_NUM}: ${msg}"
   echo > "${FAILFILE}"
   exit "${FAIL:-1}"
 fi

--- a/vtpm-many-3/test.sh
+++ b/vtpm-many-3/test.sh
@@ -34,6 +34,7 @@ fi
 copy_elf_busybox_container "$(which swtpm)"
 copy_elf_busybox_container "$(which swtpm_ioctl)"
 copy_elf_busybox_container "${VTPM_EXEC}" "bin/"
+copy_elf_busybox_container "$(which dmesg)" "bin/"
 
 # The following test needs swtpm and ${VTPM_EXEC} copied
 if ! check_ns_vtpm_support; then


### PR DESCRIPTION
On heavily loaded systems some functions may not be able to complete in time. Display some helpful messages from appropriate sources (like dmesg) depending on where the timeout occurred.