### PR TITLE
common: Pass SECURITYFS_MNT env variable to namespace scripts and use it

### DIFF
--- a/appraise-1/appraise.sh
+++ b/appraise-1/appraise.sh
@@ -6,7 +6,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -15,7 +15,7 @@ keyctl newring _ima @s >/dev/null 2>&1
 
 # There should be no measurement of the key when it gets loaded due to 'foobar' keyring
 prepolicy1="measure func=KEY_CHECK keyrings=foobar \n"
-printf "${prepolicy1}" > /mnt/ima/policy || {
+printf "${prepolicy1}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set key measurement policy. Does IMA-ns support IMA-measure?"
   exit "${SKIP:-3}"
 }
@@ -23,7 +23,7 @@ printf "${prepolicy1}" > /mnt/ima/policy || {
 keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
 
 # Expecting NO measurement of key
-ctr=$(grep -c " _ima " /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c " _ima " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 0 ]; then
   echo " Error: Could find measurement of key in container's measurement list even though none should be there"
   exit "${FAIL:-1}"
@@ -31,7 +31,7 @@ fi
 
 # This time there must be a measurement of the key when it gets loaded
 prepolicy2="measure func=KEY_CHECK \n"
-printf "${prepolicy2}" > /mnt/ima/policy || {
+printf "${prepolicy2}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set key measurement policy. Does IMA-ns support IMA-measure?"
   exit "${SKIP:-3}"
 }
@@ -39,7 +39,7 @@ printf "${prepolicy2}" > /mnt/ima/policy || {
 keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
 
 # Expecting measurement of key
-ctr=$(grep -c " _ima " /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c " _ima " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find measurement of key in container's measurement list."
   exit "${FAIL:-1}"
@@ -56,13 +56,13 @@ fi
 policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
 
 # Using busybox2 must fail since it's not signed
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute unsigned files even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
@@ -70,15 +70,15 @@ fi
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox  >/dev/null 2>&1
 
-template=$(get_template_from_log "/mnt")
+template=$(get_template_from_log "${SECURITYFS_MNT}")
 case "${template}" in
 ima-sig|ima-ns) num_extra=1;;
 *) num_extra=0;;
 esac
 
-before=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+before=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 policy="${prepolicy1}${prepolicy2}${policy}"
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -87,7 +87,7 @@ if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-after=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+after=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 expected=$((before + num_extra))
 if [ "${expected}" -ne "${after}" ]; then
   echo " Error: Could not find ${expected} measurement of busybox2 in container, found ${after}."

--- a/appraise-1/reappraise-after-host-file-modification.sh
+++ b/appraise-1/reappraise-after-host-file-modification.sh
@@ -14,7 +14,7 @@ SYNCFILE=${SYNCFILE:-syncfile} # keep shellcheck happy
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -33,13 +33,13 @@ fi
 policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
 
 # Using busybox2 must fail since it's not signed
-if "${TESTEXE}" cat /mnt/ima/policy >/dev/null 2>&1; then
+if "${TESTEXE}" cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute unsigned file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
@@ -47,7 +47,7 @@ fi
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 "${TESTEXE}"  >/dev/null 2>&1
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox  >/dev/null 2>&1
 
-nspolicy=$("${TESTEXE}" cat /mnt/ima/policy)
+nspolicy=$("${TESTEXE}" cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -57,7 +57,7 @@ if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
 fi
 
 # ima-sig gives us 2 entry already, ima-ng shows only 1
-before=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+before=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 
 # Let the host script know that it should modify the file now
 echo > "${SYNCFILE}"
@@ -74,19 +74,19 @@ while [ -f "${SYNCFILE}" ]; do
 done
 
 # Using busybox2 must fail since it's not signed correctly anymore
-if "${TESTEXE}" cat /mnt/ima/policy >/dev/null 2>&1; then
+if "${TESTEXE}" cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute badly signed file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
 
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 "${TESTEXE}" >/dev/null 2>&1
 # Using busybox2 must work now since it's properly signed again
-if ! "${TESTEXE}" cat /mnt/ima/policy >/dev/null 2>&1; then
+if ! "${TESTEXE}" cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could NOT execute signed file after re-signing"
    exit "${FAIL:-1}"
 fi
 
-after=$(grep -c "${TESTEXE}" /mnt/ima/ascii_runtime_measurements)
+after=$(grep -c "${TESTEXE}" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "$((before * 2))" -ne "${after}" ]; then
   echo " Error: Could not find $((before * 2)) measurement(s) of ${TESTEXE} in container, found ${after}."
   exit "${FAIL:-1}"

--- a/appraise-1/reappraise-after-sign-with-unknown-key.sh
+++ b/appraise-1/reappraise-after-sign-with-unknown-key.sh
@@ -6,7 +6,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -27,13 +27,13 @@ fi
 policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
 
 # Using busybox2 must fail since it's not signed
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute unsigned file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
@@ -41,7 +41,7 @@ fi
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox  >/dev/null 2>&1
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -51,24 +51,24 @@ if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
 fi
 
 # ima-sig gives us 2 entry already, ima-ng shows only 1
-before=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+before=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 
 # Sign busybox2 with key unknown to IMA
 evmctl ima_sign --imasig --key "${KEY2}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 # Using busybox2 must fail since it's not signed correctly anymore
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute badly signed file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
 
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 # Using busybox2 must work again now since signature is correct
-if ! busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if ! busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could NOT execute signed file after re-signing"
    exit "${FAIL:-1}"
 fi
 
-after=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+after=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "$((before * 2 - 1))" -ne "${after}" ]; then
   echo " Error: Could not find $((before * 2 - 1)) measurement(s) of busybox2 in container, found ${after}."
   exit "${FAIL:-1}"

--- a/appraise-1/reappraise.sh
+++ b/appraise-1/reappraise.sh
@@ -6,7 +6,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -25,13 +25,13 @@ fi
 policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
 
 # Using busybox2 must fail since it's not signed
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute unsigned file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
@@ -39,7 +39,7 @@ fi
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox  >/dev/null 2>&1
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -49,24 +49,24 @@ if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
 fi
 
 # ima-sig gives us 2 entry already, ima-ng shows only 1
-before=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+before=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 
 # Modify file to invalidate signature
 echo >> /bin/busybox2
 # Using busybox2 must fail since it's not signed correctly anymore
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could execute badly signed file even though appraise policy is active"
    exit "${FAIL:-1}"
 fi
 
 evmctl ima_sign --imasig --key "${KEY}" -a sha256 /bin/busybox2 >/dev/null 2>&1
 # Using busybox2 must work again now since signature is correct
-if ! busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if ! busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
    echo " Error: Could NOT execute signed file after re-signing"
    exit "${FAIL:-1}"
 fi
 
-after=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+after=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "$((before * 2))" -ne "${after}" ]; then
   echo " Error: Could not find $((before * 2)) measurement(s) of busybox2 in container, found ${after}."
   exit "${FAIL:-1}"

--- a/appraise-3/child.sh
+++ b/appraise-3/child.sh
@@ -14,7 +14,7 @@ CMDFILE=${CMDFILE:-cmdfile}
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 i=1
 while :; do

--- a/appraise-3/parent.sh
+++ b/appraise-3/parent.sh
@@ -7,7 +7,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -37,7 +37,7 @@ keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
 policy='measure func=KEY_CHECK \n'\
 'appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraisal?"
   exit "${SKIP:-3}"
 }

--- a/appraise-4/odirect.sh
+++ b/appraise-4/odirect.sh
@@ -7,7 +7,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -35,7 +35,7 @@ done
 policy='dont_appraise fsmagic=0x73636673 \n'\
 'appraise func=FILE_CHECK mask=MAY_READ uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
@@ -54,7 +54,7 @@ fi
 rm -f outputfile
 
 policyadd='appraise func=FILE_CHECK mask=MAY_READ uid=0 permit_directio \n'
-printf "${policyadd}" > /mnt/ima/policy || {
+printf "${policyadd}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
@@ -65,7 +65,7 @@ if ! "${dd}" if=inputfile iflag=direct of=outputfile oflag=direct status=none; t
    exit "${FAIL:-1}"
 fi
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 policy="${policy}${policyadd}"
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."

--- a/appraise-6/setxattr-check.sh
+++ b/appraise-6/setxattr-check.sh
@@ -22,7 +22,7 @@ get_hash_algo_strings()
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 ALGOS=${ALGOS:-1}
 KEY=./rsakey.pem
@@ -32,7 +32,7 @@ algos_str=$(get_hash_algo_strings "${ALGOS}")
 
 policy="appraise func=SETXATTR_CHECK appraise_algos=${algos_str} \n"
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy with SETXATTR_CHECK rule. Does IMA-ns support IMA-appraise?"
   echo " policy: |${policy}|"
   exit "${SKIP:-3}"

--- a/appraise-7/setxattr.sh
+++ b/appraise-7/setxattr.sh
@@ -15,7 +15,7 @@ for f in good*; do
   fi
 done
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 for f in good*; do
   if ! evmctl ima_sign --imasig --key "${KEY}" -a sha256 "${f}" >/dev/null 2>&1 ; then

--- a/appraise-7/test.sh
+++ b/appraise-7/test.sh
@@ -62,7 +62,7 @@ touch "${rootfs}/bad3"
 chown "0:0" "${rootfs}/bad3"
 
 sudo -u "${TEST_USER}" \
-  env PATH=/bin:/usr/bin \
+  env PATH=/bin:/usr/bin SECURITYFS_MNT=/mnt \
   unshare --user --map-root-user --mount-proc \
     --pid --fork --root "${rootfs}" bin/sh ./setxattr.sh
 rc=$?

--- a/appraise-8/appraise.sh
+++ b/appraise-8/appraise.sh
@@ -6,7 +6,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt" "sha256" "ima-sig"
+mnt_securityfs "${SECURITYFS_MNT}" "sha256" "ima-sig"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -34,7 +34,7 @@ policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=MMAP_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
@@ -76,7 +76,7 @@ if ! evmctl --help >/dev/null; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c "${libimaevm} " /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c "${libimaevm} " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 exp=2
 if [ "${ctr}" -ne "${exp}" ]; then
   echo " Error: Expected ${exp} measurements of ${libimaevm} but found ${ctr}."

--- a/appraise-many-2/appraise.sh
+++ b/appraise-many-2/appraise.sh
@@ -33,14 +33,14 @@ load_policy()
   policy='measure func=KEY_CHECK \n'\
 'appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
-  printf "${policy}" > /mnt/ima/policy || {
+  printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
     echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraisal?"
   }
 }
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -134,7 +134,7 @@ while [ "${stage}" -le 14 ]; do
       ;;
     load-key2)
       key2=$(load_key "${CERT2}")
-      ctr=$(grep -c " _ima " /mnt/ima/ascii_runtime_measurements)
+      ctr=$(grep -c " _ima " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
       if [ "${ctr}" -ne 1 ]; then
         echo "Error: Expected to find key in measurement list."
         echo > "${FAILFILE}"

--- a/appraise-many-3/appraise.sh
+++ b/appraise-many-3/appraise.sh
@@ -27,7 +27,7 @@ load_policy()
 'appraise func=SETXATTR_CHECK appraise_algos=sha256,sha512 \n'\
 'appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 gid=0 fowner=0 fgroup=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 gid=0 fowner=0 fgroup=0 \n'
-  printf "${policy}" > /mnt/ima/policy || {
+  printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
     echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraisal?"
     echo > "${FAILFILE}"
   }
@@ -76,7 +76,7 @@ create_own_key()
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -164,7 +164,7 @@ while [ "${stage}" -le 14 ]; do
        ;;
     load-own-key)
       load_key "${own_cert}" >/dev/null
-      ctr=$(grep -c " _ima " /mnt/ima/ascii_runtime_measurements)
+      ctr=$(grep -c " _ima " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
       if [ "${ctr}" -ne 1 ]; then
         echo " Error: Expected to find key in measurement list."
         echo > "${FAILFILE}"

--- a/audit+measure-1/measure+audit.sh
+++ b/audit+measure-1/measure+audit.sh
@@ -8,7 +8,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -16,7 +16,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -25,7 +25,7 @@ if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"

--- a/audit+measure-1/open_writers.sh
+++ b/audit+measure-1/open_writers.sh
@@ -11,7 +11,7 @@ SYNCFILE=${SYNCFILE:-syncfile}
 imahash="sha1"
 imatemplate="ima-ng"
 hashlen=$(($(get_hash_length "${imahash}") * 2))
-mnt_securityfs "/mnt" "${imahash}" "${imatemplate}"
+mnt_securityfs "${SECURITYFS_MNT}" "${imahash}" "${imatemplate}"
 
 echo "testtest" > testfile
 
@@ -21,7 +21,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(cat /mnt/ima/policy)
+nspolicy=$(cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -38,7 +38,7 @@ exec 101>&-
 
 # expecting an entry like this:
 #10 0000000000000000000000000000000000000000 ima-ng sha1:0000000000000000000000000000000000000000 /run/imatest/rootfs/testfile
-ctr=$(grep -c -E "^10 [0]{40} ${imatemplate} ${imahash}:[0]{${hashlen}} .*rootfs/testfile" /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c -E "^10 [0]{40} ${imatemplate} ${imahash}:[0]{${hashlen}} .*rootfs/testfile" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 entry for violation in container, found ${ctr}."
   exit "${FAIL:-1}"

--- a/audit+measure-1/remeasure+reaudit.sh
+++ b/audit+measure-1/remeasure+reaudit.sh
@@ -8,7 +8,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -17,12 +17,12 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
 fi
 
 # Use busybox twice, once after modification
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 echo >> "$(which busybox2)"
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
 
 # For this one no new measurement must be made and no new audit message must be sent:
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -31,7 +31,7 @@ if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 2 ]; then
   echo " Error: Could not find 2 measurements of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"

--- a/audit+measure-1/tomtou.sh
+++ b/audit+measure-1/tomtou.sh
@@ -11,7 +11,7 @@ SYNCFILE=${SYNCFILE:-syncfile}
 imahash="sha1"
 imatemplate="ima-ng"
 hashlen=$(($(get_hash_length "${imahash}") * 2))
-mnt_securityfs "/mnt" "${imahash}" "${imatemplate}"
+mnt_securityfs "${SECURITYFS_MNT}" "${imahash}" "${imatemplate}"
 
 echo "testtest" > testfile
 
@@ -21,7 +21,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(cat /mnt/ima/policy)
+nspolicy=$(cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -37,10 +37,10 @@ exec 101>&-
 
 # expecting an entry like this:
 #10 0000000000000000000000000000000000000000 ima-ng sha1:0000000000000000000000000000000000000000 /run/imatest/rootfs/testfile
-ctr=$(grep -c -E "^10 [0]{40} ${imatemplate} ${imahash}:[0]{${hashlen}} .*rootfs/testfile" /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c -E "^10 [0]{40} ${imatemplate} ${imahash}:[0]{${hashlen}} .*rootfs/testfile" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 entry for violation in container, found ${ctr}."
-  cat /mnt/ima/ascii_runtime_measurements
+  cat "${SECURITYFS_MNT}/ima/ascii_runtime_measurements"
   exit "${FAIL:-1}"
 fi
 

--- a/audit+measure-2/reaudit+remeasure.sh
+++ b/audit+measure-2/reaudit+remeasure.sh
@@ -8,7 +8,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -16,7 +16,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -26,7 +26,7 @@ if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
 fi
 
 # Expecting 1 measurement
-ctr=$(grep -c "bin/busybox2" /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c "bin/busybox2" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"
@@ -40,10 +40,10 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-busybox2 cat /mnt/ima/policy 1>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null
 
 # Expecting 2 measurements
-ctr=$(grep -c "bin/busybox2" /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c "bin/busybox2" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 2 ]; then
   echo " Error: Could not find 2 measurement of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"

--- a/audit-1/audit.sh
+++ b/audit-1/audit.sh
@@ -6,7 +6,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -14,7 +14,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "${POLICY}" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."

--- a/audit-1/reaudit.sh
+++ b/audit-1/reaudit.sh
@@ -6,7 +6,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -15,11 +15,11 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
 fi
 
 # Use busybox twice, once after modification
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
 echo >> "$(which busybox2)"
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
 
 # For this one no new audit message must be sent:
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
 
 exit "${SUCCESS:-0}"

--- a/audit-3/reaudit.sh
+++ b/audit-3/reaudit.sh
@@ -8,7 +8,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -16,7 +16,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "$(printf "${POLICY}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -33,7 +33,7 @@ if ! wait_file_gone "${SYNCFILE}" 50; then
   exit "${FAIL:-1}"
 fi
 
-busybox2 cat /mnt/ima/policy 1>/dev/null
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null
 
 # Tell host to look at audit log now
 echo > "${SYNCFILE}"

--- a/audit-many-1/audit.sh
+++ b/audit-many-1/audit.sh
@@ -12,7 +12,7 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Wait until host has setup the policy now
 if ! wait_file_gone "${SYNCFILE}" 50; then
@@ -22,7 +22,7 @@ fi
 
 policy='audit func=BPRM_CHECK mask=MAY_EXEC uid=0 '
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "${policy}" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."

--- a/common.sh
+++ b/common.sh
@@ -279,7 +279,7 @@ function run_busybox_container()
   rootfs="$(get_busybox_container_root)"
 
   SUCCESS=${SUCCESS:-0} FAIL=${FAIL:-1} SKIP=${SKIP:-3} \
-  PATH=/bin:/usr/bin \
+  PATH=/bin:/usr/bin SECURITYFS_MNT="/mnt" \
   unshare --user --map-root-user --mount-proc --pid --fork \
     --root "${rootfs}" "$@"
   return $?
@@ -303,7 +303,7 @@ function run_busybox_container_vtpm()
   rootfs="$(get_busybox_container_root)"
 
   SUCCESS=${SUCCESS:-0} FAIL=${FAIL:-1} SKIP=${SKIP:-3} \
-  PATH=/bin:/usr/bin \
+  PATH=/bin:/usr/bin SECURITYFS_MNT="/mnt" \
   ${VTPM_EXEC} "${opt}" -- \
     unshare --user --map-root-user --mount-proc --pid --fork \
       --root "${rootfs}" "$@"
@@ -342,7 +342,7 @@ function run_busybox_container_set_policy()
   echo > "${rootfs}/${SYNCFILE}"
 
   SUCCESS=${SUCCESS:-0} FAIL=${FAIL:-1} SKIP=${SKIP:-3} \
-  PATH=/bin:/usr/bin \
+  PATH=/bin:/usr/bin SECURITYFS_MNT="${mnt}" \
   unshare --user --map-root-user --mount-proc --pid --fork \
     --root "${rootfs}" "$@" &
   unsharepid=$!
@@ -420,7 +420,7 @@ function run_busybox_container_key_session()
   rootfs="$(get_busybox_container_root)"
 
   SUCCESS=${SUCCESS:-0} FAIL=${FAIL:-1} SKIP=${SKIP:-3} \
-  PATH=/bin:/usr/bin \
+  PATH=/bin:/usr/bin SECURITYFS_MNT="/mnt" \
   unshare --user --map-root-user --mount-proc --pid --fork \
     --root "${rootfs}" keyctl session - "$@" \
     2> >(sed '/^Joined session.*/d')
@@ -439,7 +439,7 @@ function run_busybox_container_nested()
   pushd "${rootfs}" 1>/dev/null || exit "${FAIL:-1}"
 
   SUCCESS=${SUCCESS:-0} FAIL=${FAIL:-1} SKIP=${SKIP:-3} \
-  PATH="${rootfs}"/bin:"${rootfs}"/usr/bin \
+  PATH="${rootfs}"/bin:"${rootfs}"/usr/bin SECURITYFS_MNT="/mnt" \
   unshare --user --map-root-user --mount-proc --pid --fork \
     --mount "$@"
   rc=$?

--- a/evm-1/setxattr.sh
+++ b/evm-1/setxattr.sh
@@ -16,7 +16,7 @@ for f in good* bad*; do
   fi
 done
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Writing security.evm must fail also after IMA namespace is active
 for f in good* bad*; do

--- a/evm-1/test.sh
+++ b/evm-1/test.sh
@@ -62,7 +62,7 @@ touch "${rootfs}/bad3"
 chown "0:0" "${rootfs}/bad3"
 
 sudo -u "${TEST_USER}" \
-  env PATH=/bin:/usr/bin \
+  env PATH=/bin:/usr/bin SECURITYFS_MNT=/mnt \
   unshare --user --map-root-user --mount-proc \
     --pid --fork --root "${rootfs}" bin/sh ./setxattr.sh
 rc=$?

--- a/evm-2/setxattr.sh
+++ b/evm-2/setxattr.sh
@@ -20,7 +20,7 @@ for f in good* bad*; do
   fi
 done
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 # Writing security.evm must fail for as long as EVM_ALLOW_METADATA_WRITES has not been
 # written to evm file
@@ -35,9 +35,9 @@ for f in good* bad*; do
   fi
 done
 
-echo $((EVM_SETUP_COMPLETE | EVM_ALLOW_METADATA_WRITES)) > /mnt/evm
+echo $((EVM_SETUP_COMPLETE | EVM_ALLOW_METADATA_WRITES)) > "${SECURITYFS_MNT}/evm"
 printf "  Configuring EVM with EVM_ALLOW_METADATA_WRITES flag: "
-cat /mnt/evm && echo
+cat "${SECURITYFS_MNT}/evm" && echo
 
 for f in good*; do
   if ! setfattr -n security.evm -v "${EVMSIG}" "${f}" >/dev/null 2>&1 ; then

--- a/evm-2/test.sh
+++ b/evm-2/test.sh
@@ -70,7 +70,7 @@ chown "0:0" "${rootfs}/bad3"
 setfattr -n security.evm -v "${TESTEVMSIG}" "${rootfs}/bad1"
 
 sudo -u "${TEST_USER}" \
-  env PATH=/bin:/usr/bin \
+  env PATH=/bin:/usr/bin SECURITYFS_MNT=/mnt \
   unshare --user --map-root-user --mount-proc \
     --pid --fork --root "${rootfs}" bin/sh ./setxattr.sh
 rc=$?

--- a/evm-3/appraise.sh
+++ b/evm-3/appraise.sh
@@ -6,7 +6,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 KEY=./rsakey.pem
 CERT=./rsa.crt
@@ -15,7 +15,7 @@ keyctl newring _ima @s >/dev/null 2>&1
 keyctl newring _evm @s >/dev/null 2>&1
 
 prepolicy1="measure func=KEY_CHECK keyrings=_evm|_ima \n"
-printf "${prepolicy1}" > /mnt/ima/policy || {
+printf "${prepolicy1}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set key measurement policy."
   exit "${FAIL:-1}"
 }
@@ -24,7 +24,7 @@ keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
 keyctl padd asymmetric "" %keyring:_evm < "${CERT}" >/dev/null 2>&1
 
 # Expecting measurement of both keys
-ctr=$(grep -c -E " _(ima|evm) " /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c -E " _(ima|evm) " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 exp=2
 if [ "${ctr}" -ne "${exp}" ]; then
   echo " Error: Expected ${exp} measurements of keys in container's measurement list, but found ${ctr}."
@@ -32,9 +32,9 @@ if [ "${ctr}" -ne "${exp}" ]; then
 fi
 
 # To be able to write security.evm set EVM_ALLOW_METADATA flag
-echo $((EVM_ALLOW_METADATA_WRITES)) > /mnt/evm
+echo $((EVM_ALLOW_METADATA_WRITES)) > "${SECURITYFS_MNT}/evm"
 printf "  Configuring EVM with EVM_ALLOW_METADATA_WRITES flag: "
-cat /mnt/evm ; echo
+cat "${SECURITYFS_MNT}/evm" ; echo
 
 # Sign tools to be able to use them later on
 for t in getfattr setfattr evmctl; do
@@ -53,13 +53,13 @@ done
 policy='appraise func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'\
 'measure func=BPRM_CHECK mask=MAY_EXEC uid=0 \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${FAIL:-1}"
 }
 
 # Using busybox2 must fail since it's not signed
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
   echo " Error: Could execute unsigned busybox2 even though appraise policy is active"
   exit "${FAIL:-1}"
 fi
@@ -67,15 +67,15 @@ fi
 evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(type -P busybox2)" >/dev/null 2>&1
 evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(type -P busybox)"  >/dev/null 2>&1
 
-template=$(get_template_from_log "/mnt")
+template=$(get_template_from_log "${SECURITYFS_MNT}")
 case "${template}" in
 ima-sig|ima-ns) num_extra=1;;
 *) num_extra=0;;
 esac
 
-before=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+before=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 policy="${prepolicy1}${policy}"
 if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -84,7 +84,7 @@ if [ "$(printf "${policy}")" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-after=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+after=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 expected=$((before + num_extra))
 if [ "${expected}" -ne "${after}" ]; then
   echo " Error: Could not find ${expected} measurement of busybox2 in container, found ${after}."
@@ -98,14 +98,14 @@ if ! setfattr -x security.evm "$(type -P busybox2)"; then
 fi
 
 # Using busybox2 must still work since it's still signed with IMA signature
-if ! busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if ! busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
   echo " Error: Could not execute "
   exit "${FAIL:-1}"
 fi
 
-echo $((EVM_INIT_X509)) > /mnt/evm
+echo $((EVM_INIT_X509)) > "${SECURITYFS_MNT}/evm"
 printf "  Configuring EVM with EVM_INIT_X509 flag: "
-cat /mnt/evm ; echo
+cat "${SECURITYFS_MNT}/evm" ; echo
 
 # A bad EVM signature (unknown key) that must not allow the file to execute anymore
 EVMSIG="0x050204f55d1ddc01007edb34de4276aa03ff00de1f1d3510f4f96310a6a03a3f1e526a211db6746d95e66f5eca1b4165a50d0cd9a70866ee531bde43164a35c27e18c3cc22203d6fb99162017318d73700210aa9b55668b111a66915650bfc6be50f4697145d87249d71c86b851a3c592b28e6f2b5a736d64c020c2131591b003c7633fcbc9de9dc15486cc7a32256bade1f68eb10cee77fd01dc0dc549ba1b90187368619bf36beac7669a674c022471ac8b271acccd182db9f468cd671d1b2c780dbbc9eddf41d44d20fb4f341a4fd32dedc1082db9e14eba320954fe147d0638cb90a11161aa0dc2e22eb89a0623db4058cf5fe0458245db7d0626b2d71f8fe13139240431c21e9"
@@ -115,7 +115,7 @@ if ! setfattr -n security.evm -v "${EVMSIG}" "$(type -P busybox2)"; then
 fi
 
 # Using busybox2 must not work since the EVM signature is bad
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
   echo " Error: Could execute busybox2 with bad EVM signature"
   getfattr -m ^security.evm -e hex --dump "$(type -P busybox2)"
   exit "${FAIL:-1}"
@@ -129,7 +129,7 @@ if ! setfattr -x security.ima "$(type -P busybox2)"; then
 fi
 
 # Using busybox2 must not work anymore since it's completely unsigned
-if busybox2 cat /mnt/ima/policy >/dev/null 2>&1; then
+if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
   echo " Error: Could execute unsigned busybox2"
   exit "${FAIL:-1}"
 fi

--- a/hash-1/hash.sh
+++ b/hash-1/hash.sh
@@ -6,11 +6,11 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='hash func=FILE_CHECK mask=MAY_READ \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise+hash policy. Does IMA-ns support IMA-appraise and hash rules?"
   exit "${SKIP:-3}"
 }

--- a/hash-2/hash.sh
+++ b/hash-2/hash.sh
@@ -8,11 +8,11 @@
 
 SYNCFILE=${SYNCFILE:-syncfile}
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='hash func=FILE_CHECK mask=MAY_READ \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise+hash policy. Does IMA-ns support IMA-appraise and hash rules?"
   exit "${SKIP:-3}"
 }

--- a/measure-1/measure.sh
+++ b/measure-1/measure.sh
@@ -4,16 +4,16 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0 fowner=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "${policy} " != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -22,7 +22,7 @@ if [ "${policy} " != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"

--- a/measure-1/remeasure.sh
+++ b/measure-1/remeasure.sh
@@ -4,18 +4,18 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set audit policy."
   exit "${SKIP:-3}"
 }
 
 # Use busybox twice, once after modification
-busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   exit "${FAIL:-1}"
@@ -26,8 +26,8 @@ echo >> "$(which busybox2)"
 # test re-measuring twice; one more measurement is expected
 loop=0
 while [ "$loop" -le 1 ]; do
-  busybox2 cat /mnt/ima/policy 1>/dev/null 2>/dev/null
-  ctr="$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)"
+  busybox2 cat "${SECURITYFS_MNT}/ima/policy" 1>/dev/null 2>/dev/null
+  ctr="$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")"
   if [ "${ctr}" -ne 2 ]; then
     echo " Error: Could not find 2 measurements of busybox2 in container, found ${ctr}."
     exit "${FAIL:-1}"

--- a/measure-2/configure-ima-ns.sh
+++ b/measure-2/configure-ima-ns.sh
@@ -48,7 +48,7 @@ get_template()
 
 hash_algo=$(get_hash "${ID}")
 template=$(get_template "${ID}")
-mntdir="/mnt"
+mntdir="${SECURITYFS_MNT}"
 
 if ! msg=$(mount -t securityfs "${mntdir}" "${mntdir}" 2>&1); then
   echo " Error: Could not mount securityfs: ${msg}"

--- a/measure-4/feed-many-rules.sh
+++ b/measure-4/feed-many-rules.sh
@@ -8,7 +8,7 @@
 
 . ./ns-common.sh
 
-mnt_securityfs /mnt
+mnt_securityfs "${SECURITYFS_MNT}"
 
 num_rules=0
 rule="measure func=FILE_CHECK mask=MAY_READ \n"
@@ -23,8 +23,8 @@ old_ctr=0
 while :; do
   # writing to policy will never fail since the kernel fs release operation
   # doesn't do anything with any error
-  printf "${policy}" > /mnt/ima/policy
-  ctr=$(grep -c ^ /mnt/ima/policy)
+  printf "${policy}" > "${SECURITYFS_MNT}/ima/policy"
+  ctr=$(grep -c ^ "${SECURITYFS_MNT}/ima/policy")
   if [ "${ctr}" -gt "${LIMIT_RULES}" ]; then
     echo " Error: Number of rules in policy (${ctr}) exceed limit of ${LIMIT_RULES}"
     exit "${FAIL:-1}"

--- a/measure-5/measure.sh
+++ b/measure-5/measure.sh
@@ -6,12 +6,12 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0 template=ima-ng \n'\
 'measure func=MMAP_CHECK mask=MAY_EXEC uid=0 template=ima-sig \n'
 
-printf "${policy}" > /mnt/ima/policy || {
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
   exit "${SKIP:-3}"
 }
@@ -21,7 +21,7 @@ evmctl --help >/dev/null
 
 libimaevm="$(find / 2>/dev/null| grep libimaevm)"
 
-ctr=$(grep -c "${libimaevm} " /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c "${libimaevm} " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 exp=1
 if [ "${ctr}" -ne "${exp}" ]; then
   echo " Error: Expected ${exp} measurements of ${libimaevm} but found ${ctr}."
@@ -33,14 +33,14 @@ for f in evmctl busybox; do
   fullpath="$(which "${f}")"
 
   # expect 0 log entries with ima-sig
-  ctr=$(grep " ima-sig " /mnt/ima/ascii_runtime_measurements | grep -c "${fullpath}")
+  ctr=$(grep " ima-sig " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" | grep -c "${fullpath}")
   if [ "${ctr}" -ne 0 ]; then
     echo " Error: ${f} should not have been logged with ima-sig."
     exit "${FAIL:-1}"
   fi
 
   # expect != 0 log entries with ima-ng
-  ctr=$(grep " ima-ng " /mnt/ima/ascii_runtime_measurements | grep -c "${fullpath}")
+  ctr=$(grep " ima-ng " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" | grep -c "${fullpath}")
   if [ "${ctr}" -eq 0 ]; then
     echo " Error: ${f} should have been logged with ima-ng."
     exit "${FAIL:-1}"
@@ -48,12 +48,12 @@ for f in evmctl busybox; do
 done
 
 # Libraries are only to be found with template 'ima-sig'
-ctr=$(grep " ima-sig " /mnt/ima/ascii_runtime_measurements | grep -c -E "\.so\.")
+ctr=$(grep " ima-sig " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" | grep -c -E "\.so\.")
 if [ "${ctr}" -eq 0 ]; then
   echo " Error: shared libraries should have been logged with template ima-sig."
   exit "${FAIL:-1}"
 fi
-ctr=$(grep " ima-ng " /mnt/ima/ascii_runtime_measurements | grep -c -E "\.so\.")
+ctr=$(grep " ima-ng " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" | grep -c -E "\.so\.")
 if [ "${ctr}" -ne 0 ]; then
   echo " Error: No shared libraries should have been logged with template ima-ng."
   exit "${FAIL:-1}"

--- a/measure-many-1/measure.sh
+++ b/measure-many-1/measure.sh
@@ -10,16 +10,16 @@
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0 '
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "${policy}" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -29,7 +29,7 @@ if [ "${policy}" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   echo > "${FAILFILE}"

--- a/measure-many-2/measure.sh
+++ b/measure-many-2/measure.sh
@@ -15,7 +15,7 @@ POLICYDEPTH=${POLICYDEPTH:-${MAXDEPTH}} # up to which level to create a policy
 
 [ -z "${DEPTH}" ] && { exit 1 ; }
 
-MNT="./mnt-${DEPTH}"
+MNT=".${SECURITYFS_MNT}-${DEPTH}"
 
 if [ "${DEPTH}" -le "${POLICYDEPTH}" ]; then
   mkdir -p "${MNT}"

--- a/measure-many-3/measure.sh
+++ b/measure-many-3/measure.sh
@@ -12,16 +12,16 @@ NSID=${NSID:-0}
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0 '
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-nspolicy=$(busybox2 cat /mnt/ima/policy)
+nspolicy=$(busybox2 cat "${SECURITYFS_MNT}/ima/policy")
 
 if [ "${policy}" != "${nspolicy}" ]; then
   echo " Error: Bad policy in namespace."
@@ -31,7 +31,7 @@ if [ "${policy}" != "${nspolicy}" ]; then
   exit "${FAIL:-1}"
 fi
 
-ctr=$(grep -c busybox2 /mnt/ima/ascii_runtime_measurements)
+ctr=$(grep -c busybox2 "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr}" -ne 1 ]; then
   echo " Error: Could not find 1 measurement of busybox2 in container, found ${ctr}."
   echo > "${FAILFILE}"
@@ -70,7 +70,7 @@ i=0
 while [ "${i}" -lt "${numfiles}" ]; do
   testfile="tf-${NSID}-${i}x"
   rm -f "${testfile}"
-  ctr=$(grep -c "${testfile}" /mnt/ima/ascii_runtime_measurements)
+  ctr=$(grep -c "${testfile}" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
   if [ "${ctr}" -ne "${loops}" ]; then
     echo > "${FAILFILE}"
     echo " Error: COuld not find ${testfile} ${loops} times in measurement list, but ${ctr} times"

--- a/measure-many-4/measure.sh
+++ b/measure-many-4/measure.sh
@@ -12,18 +12,18 @@ NSID=${NSID:-0}
 
 . ./ns-common.sh
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0 '
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
 testfile="testfile"
 
-imahash="$(determine_file_hash_from_log "/mnt")"
+imahash="$(determine_file_hash_from_log "${SECURITYFS_MNT}")"
 
 reported=0
 
@@ -54,27 +54,27 @@ while [ "${i}" -lt 20 ]; do
 
     ./"${testfile}" 1>/dev/null
 
-    ctr=$(grep -c "${testfile}" /mnt/ima/ascii_runtime_measurements)
+    ctr=$(grep -c "${testfile}" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
     if [ "${ctr}" -ne "${i}" ]; then
       if [ "${reported}" -eq 0 ]; then
         echo " Error in ns ${NSID} round ${i}: Could not find ${i} measurement(s), found ${ctr}."
         reported=1
         if [ ! -f "${FAILFILE}" ]; then
           echo > "${FAILFILE}"
-          cat -n /mnt/ima/ascii_runtime_measurements
+          cat -n "${SECURITYFS_MNT}/ima/ascii_runtime_measurements"
         fi
       fi
     fi
 
     filehash="$(hash_file "${imahash}" "${testfile}")"
-    ctr=$(grep -c "${filehash}" /mnt/ima/ascii_runtime_measurements)
+    ctr=$(grep -c "${filehash}" "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
     if [ "${ctr}" -ne 1 ]; then
       if [ "${reported}" -eq 0 ]; then
         echo " Error in ns ${NSID}: Could not find hash ${filehash} in measurement(s)."
         reported=1
         if [ ! -f "${FAILFILE}" ]; then
           echo > "${FAILFILE}"
-          cat -n /mnt/ima/ascii_runtime_measurements
+          cat -n "${SECURITYFS_MNT}/ima/ascii_runtime_measurements"
         fi
       fi
     fi

--- a/measure-many-5/measure.sh
+++ b/measure-many-5/measure.sh
@@ -95,7 +95,7 @@ create_ima_ns()
 testfile="testfile"
 bakfile="bakfile"
 cmdfile="cmdfile"
-mntdir="/mnt"
+mntdir="${SECURITYFS_MNT}"
 
 stage=0
 while [ "${stage}" -le 6 ]; do

--- a/measure-many-6/selinux-labels.sh
+++ b/measure-many-6/selinux-labels.sh
@@ -11,7 +11,7 @@ SYNCFILE=${SYNCFILE:-syncfile}
 
 create_imans()
 {
-  mnt_securityfs "/mnt"
+  mnt_securityfs "${SECURITYFS_MNT}"
 }
 
 get_policy_string()
@@ -37,7 +37,7 @@ check_policy()
   local policy tmp
 
   policy="$(get_policy_string "${has_rules}")"
-  tmp="$(cat "/mnt/ima/policy")"
+  tmp="$(cat "${SECURITYFS_MNT}/ima/policy")"
   if [ "${tmp}" != "$(printf "${policy}")" ]; then
     echo " Error: Unexpected policy in namespace"
     echo " expected: |${policy}|"
@@ -63,7 +63,7 @@ set_policy()
   local policy tmp
 
   policy="$(get_policy_string 1)"
-  printf "${policy}" > "/mnt/ima/policy"
+  printf "${policy}" > "${SECURITYFS_MNT}/ima/policy"
   check_policy_has_label
 }
 
@@ -93,7 +93,7 @@ measure_loop()
   fi
 
   while [ ! -f "${donefile}" ]; do
-    cat "/mnt/ima/policy" >/dev/null
+    cat "${SECURITYFS_MNT}/ima/policy" >/dev/null
     if [ "${NSID}" -le "${limit}" ]; then
       "./${myfile}" >/dev/null
       printf "a" >> "${myfile}"

--- a/vtpm-1/measure.sh
+++ b/vtpm-1/measure.sh
@@ -9,22 +9,22 @@
 # start vTPM before IMA-ns activation
 start_swtpm_chardev "0" "${VTPM_DEVICE_FD}" --log level=2,file=/swtpm.log
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-cat /mnt/ima/ascii_runtime_measurements >/dev/null
+cat "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" >/dev/null
 
 # TPM_ORD_Extend = 0x00000014
 ctr_extends=$(grep -c \
                    -E '^ 00 C1 00 00 00 22 00 00 00 14 00 00 00 0A .. ..' \
                    /swtpm.log)
-ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
+ctr_measure=$(grep -c ^ "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
   msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
   echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \

--- a/vtpm-2/measure.sh
+++ b/vtpm-2/measure.sh
@@ -9,22 +9,22 @@
 # start vTPM before IMA-ns activation
 start_swtpm_chardev "0" "${VTPM_DEVICE_FD}" --log level=2,file=/swtpm.log --tpm2
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-cat /mnt/ima/ascii_runtime_measurements >/dev/null
+cat "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" >/dev/null
 
 # TPM_CC_PCR_Extend = 0x00000182
 ctr_extends=$(grep -c \
                    -E '^ 80 02 00 00 0. .. 00 00 01 82 00 00 00 0A 00 00' \
                    /swtpm.log)
-ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
+ctr_measure=$(grep -c ^ "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
   msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
   echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \

--- a/vtpm-many-1/measure.sh
+++ b/vtpm-many-1/measure.sh
@@ -16,22 +16,22 @@ SWTPM_LOG="/swtpm-${NSID}/log"
 # start vTPM before IMA-ns activation
 start_swtpm_chardev "${NSID}" "${VTPM_DEVICE_FD}" --log "level=2,file=${SWTPM_LOG}"
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-cat /mnt/ima/ascii_runtime_measurements >/dev/null
+cat "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" >/dev/null
 
 # TPM_ORD_Extend = 0x00000014
 ctr_extends=$(grep -c \
                    -E '^ 00 C1 00 00 00 22 00 00 00 14 00 00 00 0A .. ..' \
                    "${SWTPM_LOG}")
-ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
+ctr_measure=$(grep -c ^ "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
   msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
   echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \

--- a/vtpm-many-2/measure.sh
+++ b/vtpm-many-2/measure.sh
@@ -16,22 +16,22 @@ SWTPM_LOG="/swtpm-${NSID}/log"
 # start vTPM before IMA-ns activation
 start_swtpm_chardev "${NSID}" "${VTPM_DEVICE_FD}" --log "level=2,file=${SWTPM_LOG}" --tpm2
 
-mnt_securityfs "/mnt"
+mnt_securityfs "${SECURITYFS_MNT}"
 
 policy='measure func=BPRM_CHECK mask=MAY_EXEC uid=0'
 
-echo "${policy}" > /mnt/ima/policy || {
+echo "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
   echo " Error: Could not set measure policy. Does IMA-ns support IMA-measurement?"
   exit "${SKIP:-3}"
 }
 
-cat /mnt/ima/ascii_runtime_measurements >/dev/null
+cat "${SECURITYFS_MNT}/ima/ascii_runtime_measurements" >/dev/null
 
 # TPM_CC_PCR_Extend = 0x00000182
 ctr_extends=$(grep -c \
                    -E '^ 80 02 00 00 0. .. 00 00 01 82 00 00 00 0A 00 00' \
                    "${SWTPM_LOG}")
-ctr_measure=$(grep -c ^ /mnt/ima/ascii_runtime_measurements)
+ctr_measure=$(grep -c ^ "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
 if [ "${ctr_measure}" -ne "${ctr_extends}" ]; then
   msg="$(dmesg --ctime --since '30 seconds ago' | grep "tpm${VTPM_DEVICE_NUM}:")"
   echo -e " Error: Expected ${ctr_measure} PCR_Extend's but found ${ctr_extends}.\n" \


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>