### PR TITLE
WIP: Run appraise-many-1/test.sh under UML (NOT WORKING)

### DIFF
--- a/appraise-many-1/test-uml.sh
+++ b/appraise-many-1/test-uml.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+# set -x
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+setup_busybox_container
+
+rootfs="$(get_busybox_container_root)"
+
+cp -rp "${ROOT}" "${rootfs}"
+
+copy_elf_busybox_container "$(type -P busybox)" "bin/"
+copy_elf_busybox_container "$(type -P keyctl)"
+copy_elf_busybox_container "$(type -P evmctl)"
+copy_elf_busybox_container "$(type -P getfattr)"
+copy_elf_busybox_container "$(type -P setfattr)"
+copy_elf_busybox_container "$(type -P unshare)"
+copy_elf_busybox_container "$(type -P bash)" "bin/"
+
+source "${ROOT}/common.sh"
+
+uml_run_script bin/bash /appraise-many-1/test.sh

--- a/appraise-many-1/test.sh
+++ b/appraise-many-1/test.sh
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 # shellcheck disable=SC1091
-#set -x
+# set -x
+
+mount -t proc proc /proc
+mkdir /sys
+mount -t sysfs sysfsc /sys
+mount -t securityfs securityfs /sys/kernel/security
 
 DIR="$(dirname "$0")"
 ROOT="${DIR}/.."
@@ -20,6 +25,7 @@ setup_busybox_container \
 	"${ROOT}/keys/rsa.crt"
 
 # requires check.sh
+set -x
 if ! check_ns_appraise_support; then
   echo " Error: IMA-ns does not support IMA-appraise"
   exit "${SKIP:-3}"

--- a/uml_chroot.sh
+++ b/uml_chroot.sh
@@ -15,7 +15,7 @@ cd "$(dirname "$0")" || exit_test 1
 
 # We need to copy the filesystem into an image so UML can set xattrs
 if [ ! -f .myimage ]; then
-  if ! err=$(dd if=/dev/zero of=.myimage bs=1M count=20 2>&1); then
+  if ! err=$(dd if=/dev/zero of=.myimage bs=1M count=100 2>&1); then
     echo "Error: dd failed: ${err}"
     exit_test 1
   fi
@@ -84,7 +84,10 @@ fi
 ./bin/busybox rm -f __exitcode
 
 mount -t proc proc /proc
-"$@" ${UML_SCRIPT:+${UML_SCRIPT}} ${UML_SCRIPT_P1:+${UML_SCRIPT_P1}}
+"$@" \
+  ${UML_SCRIPT:+${UML_SCRIPT}} \
+  ${UML_SCRIPT_P1:+${UML_SCRIPT_P1}} \
+  ${UML_SCRIPT_P2:+${UML_SCRIPT_P2}}
 
 ./bin/busybox cp __exitcode ..
 


### PR DESCRIPTION
Try to run an individual test case spawning many namespaces under UML. Set up a filesystem that contains the whole test suite and required executables and chroot'ing into this filesystem while under UML.

This currently doesn't/ will never work likely due to the chroot environment that prevents the subsequent unshare + chroot from working.

Command line to try out with:

```
sudo IMA_TEST_UML=/usr/local/bin/linux ./appraise-many-1/test-uml.sh
```

Result when running check_ns_appraise_support:

```
unshare --user --map-root-user --mount-proc --pid --fork --root /var/lib/imatest/rootfs ./check.sh appraise unshare: unshare failed: Operation not permitted
```

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>