### PR TITLE
UML: Run a few test cases entirely in UML using a UML wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Linux .config file so IMA is available and has a
 has to set the IMA_TEST_UML environment variable and have it point to the
 UML 'linux' executable. Since the test cases are running in a chroot
 environment and devices such as /dev/null have to be created for it, it is
-necessary to run the UML tests as root.
+necessary to run the UML tests as root. A list of supported test can be
+found in the file `uml-testcases`.
 
 The following command line can be used to run UML tests. The UML `linux`
 executable it assumed to be located at /usr/local/bin/linux.
@@ -282,7 +283,7 @@ The following test cases are supported:
 
 **Some** IMA-namespacing related test cases can also be run by UML.
 In this case UML is started which then creates an IMA-namespace to run the
-test case.
+test case. A list of supported tests can be found in the file `uml-ns-testcases`.
 
 ```
 sudo IMA_TEST_UML=/usr/local/bin/linux IMA_TEST_ENV=container ./imatest --testcases uml-ns-testcases --clear
@@ -292,6 +293,12 @@ To run a single test case in verbose mode use this command line:
 
 ```
 sudo IMA_TEST_UML=/usr/local/bin/linux IMA_TEST_ENV=container IMA_TEST_VERBOSE=1 ./host-measure-1/test.sh
+```
+
+Some of the tests have to be run with the run-in-uml.sh wrapper like this:
+
+```
+sudo IMA_TEST_UML=/usr/local/bin/linux IMA_TEST_ENV=container IMA_TEST_VERBOSE=1 ./run-in-uml.sh measure-4/test.sh
 ```
 
 Note that you must always set the `IMA_TEST_UML` and `IMA_TEST_ENV=container`
@@ -313,3 +320,10 @@ The following namespacing-related test cases are supported:
 | host-measure-1/test2.sh        | - " - |
 | host-measure-2/test.sh         | - " - |
 | selftest-1/test.sh             | - " - |
+| measure-1/test.sh              | - " - ; requires run-in-uml.sh |
+| measure-4/test.sh              | - " - ; requires run-in-uml.sh |
+| measure-many-1/test.sh         | - " - ; requires run-in-uml.sh |
+| measure-many-2/test.sh         | - " - ; requires run-in-uml.sh |
+| measure-many-3/test.sh         | - " - ; requires run-in-uml.sh |
+| measure-many-4/test.sh         | - " - ; requires run-in-uml.sh |
+| measure-many-5/test.sh         | - " - ; requires run-in-uml.sh |

--- a/common.sh
+++ b/common.sh
@@ -275,7 +275,8 @@ function __setup_busybox()
   fi
   pushd "${rootfs}/bin" 1>/dev/null || exit "${FAIL:-1}"
   for prg in \
-      cat chmod cut cp date dirname echo env find grep head ls mkdir mount mv printf rm \
+      cat chmod cut cp date dirname echo env find grep head id \
+      ls ln mkdir mknod mount mv printf rm \
       sed sh sha1sum sha256sum sha384sum sha512sum sleep sync \
       tail time uname which; do
     ln -s busybox ${prg}
@@ -386,7 +387,7 @@ function __post_uml_run()
   # Display linux & test output other than audit messages
   if [ "${verbosity}" -eq 0 ]; then
     # Filter-out a couple of known Linux dmesg lines
-    sed -e '1,/uml_chroot.sh as init process$/ d' \
+    sed -e '1,/\.sh as init process$/ d' \
         -e '/^audit:/d' \
         -e '/^ima:/d' \
         -e '/^integrity:/d' \

--- a/imatest
+++ b/imatest
@@ -36,16 +36,17 @@ function bannerit()
 
 function run_testcase()
 {
-  local testcasefile="$1"
-  local output="$2"
+  local wrapper="$1"
+  local testcase="$2"
+  local output="$3"
 
   local rc
 
   if [ "${output}" == "-" ] || [ -z "${output}" ]; then
-    ./"${testcasefile}"
+    ${wrapper:+./${wrapper}} ./"${testcase}"
     rc=$?
   else
-    ./"${testcasefile}" >> "${output}" 2>&1
+    ${wrapper:+./${wrapper}} ./"${testcase}" >> "${output}" 2>&1
     rc=$?
   fi
 
@@ -61,7 +62,7 @@ function imatest()
   local testcasedir
   local line=0 is_retry=0
   local testcases_lines
-  local testcase rc
+  local commandline rc
   local stats_pass=0 stats_fail=0 stats_skip=0
 
   testcases_lines=$(wc -l < "${testcases}")
@@ -99,22 +100,28 @@ function imatest()
     line=$((line + 1))
     echo "line=${line}" > "${statefile}"
 
-    testcase=$(sed -n "${line}p" "${testcases}")
-    if [ "${testcase:0:1}" != "#" ] && [ -n "$(echo "${testcase}" | tr -d " ")" ]; then
-      local testcase_dir
+    commandline=$(sed -n "${line}p" "${testcases}")
+    if [ "${commandline:0:1}" != "#" ] && [ -n "$(echo "${commandline}" | tr -d " ")" ]; then
+      local testcase testcase_dir wrapper
+
+      wrapper=$(cut -d" " -f1 <<< "${commandline}")
+      case "${wrapper}" in
+      run-in-uml.sh)
+        testcase=$(cut -d" " -f2 <<< "${commandline}")
+        ;;
+      *)
+        testcase=${commandline}
+        wrapper=""
+        ;;
+      esac
 
       testcase_dir=$(dirname "${testcase}")
 
       if [ -d "${testcase_dir}" ]; then
-        local testcasefile
-
-        testcasefile=$(basename "${testcase}")
-
-        pushd "${testcase_dir}" &>/dev/null || exit 1
         logit "${logfile}" "---------------------------------------------------------------------------------"
         logit "${logfile}" "Running testcase ${testcase} on $(uname -sr)"
 
-        run_testcase "${testcasefile}" "${logfile}"
+        run_testcase "${wrapper}" "${testcase}" "${logfile}"
         rc=$?
 
         logit "${logfile}" "Result from ${testcase}: $rc"
@@ -158,8 +165,6 @@ function imatest()
           ;;
         *) logit "${logfile}" ">>>>>>>>> Unhandled return code: ${rc}";;
         esac
-
-        popd &>/dev/null || exit 1
       fi
       is_retry=0
 

--- a/run-in-uml.sh
+++ b/run-in-uml.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+# set -x
+
+# Set up a filesystem with all the tools installed to 'busybox container root'
+# and start UML with this filesystem.
+# Note: The filesystem that UML will use does NOT let UML set xattrs. We would
+#       need to use 'chroot' for this to work but then unshare wouldn't work
+#       anymore for the test cases.
+#
+# @param1: Executable/script to run under UML
+function uml_run_script()
+{
+  local script="$1"
+
+  local rootfs rc err dev f stdoutlog stderrlog verbosity redir
+
+  rootfs="$(get_busybox_container_root)"
+
+  pushd "${rootfs}" 1>/dev/null || exit "${FAIL:-1}"
+
+  if ! err=$(dd if=/dev/zero of=.myimage bs=1M count=100 2>&1); then
+    echo "Error: dd failed: ${err}"
+    exit "${FAIL:-1}"
+  fi
+
+  if ! err=$(losetup -f .myimage --show); then
+    echo " Error: losetup failed: ${err}"
+    exit "${FAIL:-1}"
+  fi
+  dev=$err
+
+  if ! err=$(mkfs.ext4 -b 4096 "${dev}" 2>&1); then
+    echo "Error: mkfs.ext4 failed: ${err}"
+    exit "${FAIL:-1}"
+  fi
+
+  if ! err=$(mkdir mntpoint 2>&1); then
+    echo "Error: mkdir failed: ${err}"
+    exit "${FAIL:-1}"
+  fi
+
+  if ! err=$(mount -o i_version "${dev}" mntpoint 2>&1); then
+    echo "Error: mount failed: ${err}"
+    exit "${FAIL:-1}"
+  fi
+
+  for f in *; do
+    if [ "${f}" = "mntpoint" ]; then
+      continue
+    fi
+    if [ ! -e "mntpoint/${f}" ]; then
+      if ! err=$(cp -r "${f}" mntpoint 2>&1); then
+        echo "Error: cp ${f} failed: ${err}"
+        exit "${FAIL:-1}"
+      fi
+    fi
+  done
+
+  stdoutlog="${rootfs}/.stdoutlog"
+  stderrlog="${rootfs}/.stderrlog"
+  verbosity=$(get_verbosity)
+  [ "${verbosity}" -gt 0 ] && redir=/dev/stdout || redir=/dev/null
+
+  ${IMA_TEST_UML} \
+    SUCCESS="${SUCCESS:-0}" FAIL="${FAIL:-1}" SKIP="${SKIP:-3}" \
+    "$(set | grep -E "^(G_|IMA_TEST_EXPENSIVE).*=.*")" \
+    UML_SCRIPT="${script}" \
+    rootfstype=hostfs rootflags="${rootfs}/mntpoint" rw init="uml_run.sh" mem=256M \
+    1> >(tee "${stdoutlog}" 2>/dev/null | sed -z 's/\n/\n\r/g' >${redir}) \
+    2> >(tee "${stderrlog}" 2>/dev/null | sed -z 's/\n/\n\r/g' >${redir})
+  __post_uml_run "$?" "${rootfs}/mntpoint" "${stdoutlog}" "${verbosity}" "${stderrlog}"
+  rc=$?
+
+  umount mntpoint
+  losetup -d "${dev}"
+
+  popd &>/dev/null || exit 1
+
+  return "${rc}"
+}
+
+
+function setup_filesystem_for_uml()
+{
+  local testscript="$1"
+
+  local rootfs prg
+
+  # shellcheck disable=SC2119
+  setup_busybox_container
+
+  # Set up a minimal environment that most test cases can work with
+  for prg in busybox unshare bash file; do
+    copy_elf_busybox_container "$(type -P "${prg}")" "bin/"
+  done
+
+  rootfs="$(get_busybox_container_root)"
+
+  # own nproc that shows a few more CPUs than what nproc would shows in UML (1 CPU)
+  cat <<_EOF_ >> "${rootfs}/bin/nproc"
+#!/bin/bash
+echo 10
+_EOF_
+  chmod 755 "${rootfs}/bin/nproc"
+
+  cp "$(type -P ldd)" "${rootfs}/bin"
+
+  # file utility needs a few helper files
+  mkdir -p "${rootfs}/etc"
+  cp "/etc/magic" "${rootfs}/etc"
+
+  mkdir -p "${rootfs}/usr/share/misc"
+  cp -rp /usr/share/misc/ "${rootfs}/usr/share/"
+
+  # Copy common.sh ns-common.sh etc. (*.sh) and test case directory
+  cp -rpH ./*.sh "$(dirname "${testscript}")" "${rootfs}"
+}
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}"
+
+source "${ROOT}/common.sh"
+
+setup_filesystem_for_uml "$1"
+
+uml_run_script "$@"
+exit $?

--- a/uml-ns-testcases
+++ b/uml-ns-testcases
@@ -11,3 +11,10 @@ hash-1/test.sh
 host-measure-1/test.sh
 host-measure-1/test2.sh
 host-measure-2/test.sh
+run-in-uml.sh measure-1/test.sh
+run-in-uml.sh measure-4/test.sh
+run-in-uml.sh measure-many-1/test.sh
+run-in-uml.sh measure-many-2/test.sh
+run-in-uml.sh measure-many-3/test.sh
+run-in-uml.sh measure-many-4/test.sh
+run-in-uml.sh measure-many-5/test.sh

--- a/uml_run.sh
+++ b/uml_run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Setup the filesystem so that a test case can be run
+# and run the test case passed via UML_SCRIPT.
+
+# set -x
+
+exit_test()
+{
+  local rc="$1"
+
+  echo "$rc" >> __exitcode
+
+  busybox poweroff -f
+}
+
+export PATH=/bin:/usr/bin
+
+if ! mkdir /sys || \
+   ! mount -t sysfs sysfs /sys || \
+   ! mount -t proc proc /proc || \
+   ! mount -t securityfs securityfs /sys/kernel/security/ || \
+   ! ln -s /bin /usr/bin || \
+   ! mkdir -p /dev/fd; then
+  echo "Error: Could not setup filesystem"
+  exit_test 1
+fi
+
+# echo Running test script now: ${UML_SCRIPT}
+
+rm -f __exitcode
+
+"${UML_SCRIPT}"
+exit_test "$?"


### PR DESCRIPTION
Implement a wrapper script run-in-uml.sh that copies a test case and the helper script files (common.sh, ns-common.sh, etc.) and executables (busybox, bash, file, etc.) into a filesystem and starts UML with it and then runs the typical test.sh file for a test case. This now allows many of the measurement test cases to entirely run in a UML environment and also allows to run those test cases that start many containers.

Modify imatest to accept a wrapper script (run-in-uml.sh) to run a
test case.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>