### PR TITLE
tests: Use 'which' instead of 'type -P' to get full file path (Ubuntu…

### DIFF
--- a/evm-3/appraise.sh
+++ b/evm-3/appraise.sh
@@ -20,8 +20,14 @@ printf "${prepolicy1}" > "${SECURITYFS_MNT}/ima/policy" || {
   exit_test "${FAIL:-1}"
 }
 
-keyctl padd asymmetric "" %keyring:_ima < "${CERT}" >/dev/null 2>&1
-keyctl padd asymmetric "" %keyring:_evm < "${CERT}" >/dev/null 2>&1
+if ! err=$(keyctl padd asymmetric "" %keyring:_ima < "${CERT}" 2>&1); then
+  echo " Error: Could not load key onto _ima keyring: ${err}"
+  exit_test "${FAIL:-1}"
+fi
+if ! err=$(keyctl padd asymmetric "" %keyring:_evm < "${CERT}" 2>&1); then
+  echo " Error: Could not load key onto _evm keyring: ${err}"
+  exit_test "${FAIL:-1}"
+fi
 
 # Expecting measurement of both keys
 ctr=$(grep -c -E " _(ima|evm) " "${SECURITYFS_MNT}/ima/ascii_runtime_measurements")
@@ -64,8 +70,14 @@ if busybox2 cat "${SECURITYFS_MNT}/ima/policy" >/dev/null 2>&1; then
   exit_test "${FAIL:-1}"
 fi
 
-evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(type -P busybox2)" >/dev/null 2>&1
-evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(type -P busybox)"  >/dev/null 2>&1
+if ! err=$(evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(which busybox2)" 2>&1); then
+  echo " Error: Could not sign busybox2: ${err}"
+  exit_test "${FAIL:-1}"
+fi
+if ! err=$(evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(which busybox)"  2>&1); then
+  echo " Error: Could not sign busybox: ${err}"
+  exit_test "${FAIL:-1}"
+fi
 
 template=$(get_template_from_log "${SECURITYFS_MNT}")
 case "${template}" in

--- a/evm-many-1/appraise.sh
+++ b/evm-many-1/appraise.sh
@@ -24,6 +24,7 @@ printf "${prepolicy1}" > "${SECURITYFS_MNT}/ima/policy" || {
 
 # Each namespace needs its own busybox2 test file
 NSID=${NSID:-1} # for shellcheck
+BUSYBOX="$(which busybox)"
 BUSYBOX2="$(which busybox2)-${NSID}"
 cp "$(which busybox2)" "${BUSYBOX2}"
 
@@ -93,7 +94,7 @@ if ! err=$(evmctl sign --imasig --portable --key "${KEY}" -a sha256 "${BUSYBOX2}
   echo > "${FAILFILE}"
   exit_test "${FAIL:-1}"
 fi
-if ! err=$(evmctl sign --imasig --portable --key "${KEY}" -a sha256 "$(which busybox)"  2>&1); then
+if ! err=$(evmctl sign --imasig --portable --key "${KEY}" -a sha256 "${BUSYBOX}"  2>&1); then
   echo " Error: Could not sign busybox: ${err}"
   echo > "${FAILFILE}"
   exit_test "${FAIL:-1}"
@@ -127,7 +128,7 @@ fi
 
 if ! evmsig="$(getfattr -m ^security.evm -e hex --dump "${BUSYBOX2}" 2>/dev/null |
               sed  -n 's/^security.evm=//p')"; then
-  echo " Error: Could not get EVM signature from $(type -P busybox2)"
+  echo " Error: Could not get EVM signature from ${BUSYBOX2}"
   exit "${FAIL:-1}"
 fi
 


### PR DESCRIPTION
… 21.10)

On Ubuntu 21.10: In some cases 'type -P busybox' returns 'busybox' without the full path and signing the file fails. Fix this by using 'which' instead and also testing for success of 'evmctl'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>