### PR TITLE
appraise: Test creation of new session keyring does not allow evasion

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Concerns for the testing are:
 | appraise-7      | Testing of setxattr success on files with proper ownership in namespace, failures on files without proper ownership in namespace |
 | appraise-8      | Testing of BPRM_CHECK and MMAP_CHECK; test removal and restoring of signature on library |
 | appraise-9      | Testing of BPRM_CHECK and MMAP_CHECK using different templates for logging |
+| appraise-10     | Testing that a newly created session keyring with _ima keyring and new key does not allow to run an executable signed with this new key |
 | appraise-many-1 | Concurrently running IMA namespaces with own keyrings appraise executables |
 | appraise-many-2 | Concurrently running IMA namespaces test appraisal and re-appraisal of files after file and signature modifications |
 | appraise-many-3 | Concurrently running IMA namespaces test appraisal and re-appraisal of files after file and signature modifications and signing with their own private key |
@@ -315,6 +316,7 @@ The following namespacing-related test cases are supported:
 | appraise-6/test.sh             | - " - |
 | appraise-8/test.sh             | - " - |
 | appraise-9/test.sh             | - " - |
+| appraise-10/test.sh            | - " - |
 | evm-3/test.sh                  | - " - |
 | evm-4/test.sh                  | - " - |
 | hash-1/test.sh                 | - " - |

--- a/appraise-10/appraise-2nd.sh
+++ b/appraise-10/appraise-2nd.sh
@@ -1,0 +1,54 @@
+#!/bin/env sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC3028
+
+# This script is expected to run in a new session keyring where we create another
+# _ima keyring and load CERT2 onto it and sign a new file with KEY2. This file
+# must NOT be executable since this is just a new session keyring.
+
+. ./ns-common.sh
+
+echo "  INFO: In key session"
+
+keyctl newring _ima @s 1>/dev/null 2>&1
+
+if ! err=$(keyctl padd asymmetric "" %keyring:_ima < "${CERT2}" 2>&1); then
+  echo " Error: Could not load ${CERT2} onto _ima keyring: ${err}"
+  exit "${FAIL:-1}"
+fi
+
+# Check that unsigned file does not run
+if "${TESTFILE}" 2>/dev/null; then
+  echo " Error: Executing unsigned testfile must have failed"
+  exit "${FAIL:-1}"
+fi
+
+# Sign with KEY2
+if ! err=$(evmctl ima_sign --imasig --key "${KEY2}" -a sha256 "${TESTFILE}" 2>&1); then
+   echo " Error: Could not sign ${TESTFILE}: ${err}"
+   exit "${FAIL:-1}"
+fi
+
+# It still must not run
+if "${TESTFILE}" 2>/dev/null; then
+  echo " Error: Executing testfile signed with bad key must have failed"
+  exit "${FAIL:-1}"
+fi
+
+# Sanity check by signing with KEY
+if ! err=$(evmctl ima_sign --imasig --key "${KEY}" -a sha256 "${TESTFILE}" 2>&1); then
+  echo " Error: Could not sign ${TESTFILE}: ${err}"
+  exit "${FAIL:-1}"
+fi
+
+# Now it must run
+if ! "${TESTFILE}" 1>/dev/null; then
+  echo " Error: Executing testfile signed with good key (${KEY}) must work!"
+  exit "${FAIL:-1}"
+fi
+
+echo "  INFO: Test in key session passed"
+
+exit "${SUCCESS:-0}"

--- a/appraise-10/appraise.sh
+++ b/appraise-10/appraise.sh
@@ -1,0 +1,93 @@
+#!/bin/env sh
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC2059,SC3028
+
+# Create an _ima keyring under the session keyring and sign applications with a
+# key (KEY) loaded onto that keyring (CERT). Then create a new session keyring
+# along with another _ima keyring and load another key (CERT2) onto this new
+# _ima keyring and sign an application with its key (KEY2) and test that this
+# application does not run and therefore the new key (KEY2/CERT2) does not become
+# valid. This is to ensure that IF there is an existing _ima keyring (created by
+# container runtime for example) with a key loaded on it that this keyring cannot
+# be 'overridden' through a new session keyring + _ima keyring and the user can
+# put just any keys on it. If, however, there was no appraisal policy before the
+# new session keyring was created then creating the new session keyring does allow
+# loading keys onto the _ima keyring that IMA then ends up using.
+
+. ./ns-common.sh
+
+mnt_securityfs "${SECURITYFS_MNT}"
+
+KEY=./rsakey.pem
+CERT=./rsa.crt
+
+# Key for 2nd script on new session keyring
+KEY2=./rsakey2.pem
+CERT2=./rsa2.crt
+
+TESTFILE=/testfile
+
+BUSYBOX=$(which busybox)
+KEYCTL=$(which keyctl)
+
+keyctl newring _ima @s >/dev/null 2>&1
+
+if ! err=$(keyctl padd asymmetric "" %keyring:_ima < "${CERT}" 2>&1); then
+  echo " Error: Could not load ${CERT} onto _ima keyring: ${err}"
+  exit_test "${FAIL:-1}"
+fi
+
+# Sign evmctl to be able to use it later on
+evmctl ima_sign --imasig --key "${KEY}" -a sha256 /usr/bin/evmctl >/dev/null 2>&1
+if [ -z "$(getfattr -m ^security.ima -e hex --dump /usr/bin/evmctl 2>/dev/null)" ]; then
+  echo " Error: security.ima should be there now. Is IMA appraisal support enabled?"
+  # setting security.ima was only added when appraisal was enable
+  exit_test "${FAIL:-1}"
+fi
+
+policy='appraise func=BPRM_CHECK mask=MAY_EXEC \n'
+
+printf "${policy}" > "${SECURITYFS_MNT}/ima/policy" || {
+  echo " Error: Could not set appraise policy. Does IMA-ns support IMA-appraise?"
+  exit_test "${FAIL:-1}"
+}
+
+for tool in ${BUSYBOX} ${KEYCTL} /appraise-2nd.sh; do
+  if ! err=$(evmctl ima_sign --imasig --key "${KEY}" -a sha256 "${tool}" 2>&1); then
+     echo " Error: Could not sign ${tool}: ${err}"
+     exit_test "${FAIL:-1}"
+  fi
+done
+
+# Create a testfile with some random content
+cat <<_EOF_ >"${TESTFILE}"
+#!/bin/env sh
+
+echo ${RANDOM}${RANDOM}
+_EOF_
+chmod 755 "${TESTFILE}"
+
+# Check that unsigned file does not run
+if "${TESTFILE}" 2>/dev/null; then
+  echo " Error: Executing unsigned testfile must have failed"
+  exit_test "${FAIL:-1}"
+fi
+
+TESTFILE=${TESTFILE} KEY=${KEY} CERT=${CERT} KEY2=${KEY2} CERT2="${CERT2}" \
+  keyctl session - /appraise-2nd.sh
+rc=$?
+if [ $rc -ne 0 ]; then
+  exit_test "${rc}"
+fi
+
+echo " INFO: Back in original script"
+
+# Now it must run
+if ! "${TESTFILE}" 1>/dev/null; then
+  echo " Error: Executing testfile signed with good key (${KEY}) must work!"
+  exit_test "${FAIL:-1}"
+fi
+
+exit_test "${SUCCESS:-0}"

--- a/appraise-10/test.sh
+++ b/appraise-10/test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# shellcheck disable=SC1091
+#set -x
+
+DIR="$(dirname "$0")"
+ROOT="${DIR}/.."
+
+source "${ROOT}/common.sh"
+
+check_ima_support
+
+setup_busybox_container \
+	"${ROOT}/ns-common.sh" \
+	"${ROOT}/uml_chroot.sh" \
+	"${ROOT}/check.sh" \
+	"${DIR}/appraise.sh" \
+	"${DIR}/appraise-2nd.sh" \
+	"${ROOT}/keys/rsakey.pem" \
+	"${ROOT}/keys/rsa.crt" \
+	"${ROOT}/keys/rsakey2.pem" \
+	"${ROOT}/keys/rsa2.crt"
+
+if ! check_ns_appraise_support; then
+  echo " Error: IMA-ns does not support IMA-appraise"
+  exit "${SKIP:-3}"
+fi
+
+copy_elf_busybox_container "$(type -P keyctl)"
+copy_elf_busybox_container "$(type -P evmctl)"
+copy_elf_busybox_container "$(type -P getfattr)"
+copy_elf_busybox_container "$(type -P setfattr)"
+
+# Test appraisal caused by executable run in namespace
+
+echo "INFO: Testing appraisal inside container with changing of session keyring"
+
+run_busybox_container_key_session ./appraise.sh
+rc=$?
+if [ $rc -ne 0 ] ; then
+  echo " Error: Test failed in IMA namespace."
+  exit "$rc"
+fi
+
+echo "INFO: Pass"
+
+exit "${SUCCESS:-0}"

--- a/testcases
+++ b/testcases
@@ -8,6 +8,7 @@ appraise-6/test.sh
 appraise-7/test.sh
 appraise-8/test.sh
 appraise-9/test.sh
+appraise-10/test.sh
 appraise-many-1/test.sh
 appraise-many-2/test.sh
 appraise-many-3/test.sh

--- a/uml-ns-testcases
+++ b/uml-ns-testcases
@@ -5,6 +5,7 @@ appraise-5/test.sh
 appraise-6/test.sh
 appraise-8/test.sh
 appraise-9/test.sh
+appraise-10/test.sh
 evm-3/test.sh
 evm-4/test.sh
 hash-1/test.sh


### PR DESCRIPTION
Test that the creatin of a new session keyring does not allow the evasion from the originally created session keyring and its _ima keyring holding signature verification keys.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>